### PR TITLE
Command cancellation

### DIFF
--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
@@ -8,6 +8,9 @@
     <PackageProjectUrl>https://github.com/DataAction/AdoNetCore.AseClient</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/DataAction/AdoNetCore.AseClient/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netcoreapp1.1'">
+    <DefineConstants>$(DefineConstants);NETCORE_OLD</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>

--- a/src/AdoNetCore.AseClient/AseClientPermission.cs
+++ b/src/AdoNetCore.AseClient/AseClientPermission.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0 || NET45
+﻿#if !NETCORE_OLD
 using System;
 using System.Data;
 using System.Data.Common;

--- a/src/AdoNetCore.AseClient/AseClientPermissionAttribute.cs
+++ b/src/AdoNetCore.AseClient/AseClientPermissionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0 || NET45
+﻿#if !NETCORE_OLD
 using System;
 using System.Data.Common;
 using System.Security;

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -1,5 +1,8 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
 using AdoNetCore.AseClient.Internal;
 
 namespace AdoNetCore.AseClient
@@ -32,7 +35,8 @@ namespace AdoNetCore.AseClient
         /// </remarks>
         public override void Cancel()
         {
-            //todo: implement
+            Logger.Instance?.WriteLine("Cancel requested");
+            _connection.InternalConnection.Cancel();
         }
 
         /// <summary>Parameter" /> object.

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -193,7 +193,7 @@ namespace AdoNetCore.AseClient
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    Logger.Instance?.Write($"{nameof(ExecuteNonQueryAsync)} - cancellation already requested");
+                    Logger.Instance?.Write($"{nameof(InternalExecuteAsync)} - cancellation already requested");
                     source.SetCanceled();
                     return source.Task;
                 }
@@ -209,19 +209,19 @@ namespace AdoNetCore.AseClient
 
                         if (t.IsFaulted)
                         {
-                            Logger.Instance?.WriteLine($"{nameof(ExecuteNonQueryAsync)} - task faulted: {t.Exception.InnerException}");
+                            Logger.Instance?.WriteLine($"{nameof(InternalExecuteAsync)} - task faulted: {t.Exception.InnerException}");
                             source.SetException(t.Exception.InnerException);
                         }
                         else
                         {
                             if (t.IsCanceled)
                             {
-                                Logger.Instance?.WriteLine($"{nameof(ExecuteNonQueryAsync)} - task canceled");
+                                Logger.Instance?.WriteLine($"{nameof(InternalExecuteAsync)} - task canceled");
                                 source.SetCanceled();
                             }
                             else
                             {
-                                Logger.Instance?.WriteLine($"{nameof(ExecuteNonQueryAsync)} - task completed");
+                                Logger.Instance?.WriteLine($"{nameof(InternalExecuteAsync)} - task completed");
                                 source.SetResult(t.Result);
                             }
                         }
@@ -229,7 +229,7 @@ namespace AdoNetCore.AseClient
             }
             catch (Exception ex)
             {
-                Logger.Instance?.WriteLine($"{nameof(ExecuteNonQueryAsync)} - exception: {ex}");
+                Logger.Instance?.WriteLine($"{nameof(InternalExecuteAsync)} - exception: {ex}");
                 source.SetException(ex);
             }
 

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -14,7 +14,12 @@ namespace AdoNetCore.AseClient
     {
         private AseConnection _connection;
         private AseTransaction _transaction;
+        private bool _isDisposed;
         internal readonly AseParameterCollection AseParameters;
+        private CommandType _commandType;
+        private int _commandTimeout;
+        private string _commandText;
+        private UpdateRowSource _updatedRowSource;
 
         public AseCommand(AseConnection connection)
         {
@@ -35,6 +40,11 @@ namespace AdoNetCore.AseClient
         /// </remarks>
         public override void Cancel()
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             Logger.Instance?.WriteLine("Cancel requested");
             _connection.InternalConnection.Cancel();
         }
@@ -47,6 +57,11 @@ namespace AdoNetCore.AseClient
         /// </remarks>
         public new AseParameter CreateParameter()
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             return new AseParameter();
         }
 
@@ -73,22 +88,13 @@ namespace AdoNetCore.AseClient
         /// </remarks>
         public override int ExecuteNonQuery()
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             LogExecution(nameof(ExecuteNonQuery));
             return _connection.InternalConnection.ExecuteNonQuery(this, (AseTransaction)Transaction);
-        }
-
-        /// <summary>		
-        /// Sends the <see cref="CommandText" /> to the <see cref="Connection" /> and builds an <see cref="AseDataReader" />.		
-        /// </summary>		
-        /// <returns>An <see cref="AseDataReader" /> object.</returns>		
-        /// <remarks>		
-        /// <para>When the <see cref="CommandType" /> property is set to <b>StoredProcedure</b>, the <see cref="CommandText" /> property should be set to the 		
-        /// name of the stored procedure. The command executes this stored procedure when you call ExecuteReader.</para>		
-        /// <para>The ExecuteReader method is a strongly-typed version of <see cref="IDbCommand.ExecuteReader()" />.</para>		
-        /// </remarks>		
-        public new AseDataReader ExecuteReader()
-        {		
-            return ExecuteReader(CommandBehavior.Default);		
         }
 
         /// <summary>
@@ -103,8 +109,27 @@ namespace AdoNetCore.AseClient
         /// </remarks>
         public new AseDataReader ExecuteReader(CommandBehavior behavior)
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             LogExecution(nameof(ExecuteReader));
-            return (AseDataReader) _connection.InternalConnection.ExecuteReader(behavior, this, (AseTransaction) Transaction);
+            return (AseDataReader)_connection.InternalConnection.ExecuteReader(behavior, this, (AseTransaction)Transaction);
+        }
+
+        /// <summary>		
+        /// Sends the <see cref="CommandText" /> to the <see cref="Connection" /> and builds an <see cref="AseDataReader" />.		
+        /// </summary>		
+        /// <returns>An <see cref="AseDataReader" /> object.</returns>		
+        /// <remarks>		
+        /// <para>When the <see cref="CommandType" /> property is set to <b>StoredProcedure</b>, the <see cref="CommandText" /> property should be set to the 		
+        /// name of the stored procedure. The command executes this stored procedure when you call ExecuteReader.</para>		
+        /// <para>The ExecuteReader method is a strongly-typed version of <see cref="IDbCommand.ExecuteReader()" />.</para>		
+        /// </remarks>		
+        public new AseDataReader ExecuteReader()
+        {
+            return ExecuteReader(CommandBehavior.Default);
         }
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
@@ -125,6 +150,11 @@ namespace AdoNetCore.AseClient
         /// </remarks>
         public override object ExecuteScalar()
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             LogExecution(nameof(ExecuteScalar));
             return _connection.InternalConnection.ExecuteScalar(this, (AseTransaction)Transaction);
         }
@@ -144,6 +174,11 @@ namespace AdoNetCore.AseClient
         /// </summary>
         public override void Prepare()
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             // Support for prepared statements is not currently implemented. But to make this a drop in replacement for other DB Providers,
             // it's better to treat this call as a no-op, than to throw a NotImplementedException.
         }
@@ -151,25 +186,101 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// Gets or sets the Transact-SQL statement, table name or stored procedure to execute at the data source.
         /// </summary>
-        public override string CommandText { get; set; }
+        public override string CommandText
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                return _commandText;
+            }
+            set
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                _commandText = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the wait time before terminating the attempt to execute a command and generating an error.
         /// </summary>
-        public override int CommandTimeout { get; set; }
+        public override int CommandTimeout
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                return _commandTimeout;
+            }
+            set
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                _commandTimeout = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a value indicating how the <see cref="CommandText" /> property is to be interpreted.
         /// </summary>
-        public override CommandType CommandType { get; set; }
+        public override CommandType CommandType
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                return _commandType;
+            }
+            set
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                _commandType = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="AseConnection" /> used by this instance of the AseCommand.
         /// </summary>
         public new AseConnection Connection
         {
-            get => _connection;
-            set => _connection = value;
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                return _connection;
+            }
+            set
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                _connection = value;
+            }
         }
 
         protected override DbConnection DbConnection
@@ -206,7 +317,37 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// Gets or sets how command results are applied to the DataRow when used by the Update method of the DbDataAdapter.
         /// </summary>
-        public override UpdateRowSource UpdatedRowSource { get; set; }
+        public override UpdateRowSource UpdatedRowSource
+        {
+            get
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                return _updatedRowSource;
+            }
+            set
+            {
+                if (_isDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(AseCommand));
+                }
+
+                _updatedRowSource = value;
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
+            _isDisposed = true;
+        }
 
         internal bool HasSendableParameters => AseParameters?.HasSendableParameters ?? false;
 
@@ -282,16 +423,31 @@ namespace AdoNetCore.AseClient
 
         public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             return InternalExecuteAsync(() => _connection.InternalConnection.ExecuteNonQueryTaskRunnable(this, (AseTransaction)Transaction), cancellationToken);
         }
 
         protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             return InternalExecuteAsync(() => _connection.InternalConnection.ExecuteReaderTaskRunnable(behavior, this, (AseTransaction)Transaction), cancellationToken);
         }
 
         public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(AseCommand));
+            }
+
             return ExecuteReaderAsync(cancellationToken)
                 // ReSharper disable once MethodSupportsCancellation
                 .ContinueWith(task =>

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -312,17 +312,17 @@ namespace AdoNetCore.AseClient
         /// statement or the <see cref="ChangeDatabase(string)" /> method, an informational message is sent and 
         /// the property is updated automatically.
         /// </remarks>
-        public override string Database => _internal?.Database ?? string.Empty;
+        public override string Database => _internal?.Database;
 
         /// <summary>
         /// Gets the name of the current server
         /// </summary>
-        public override string DataSource => _internal?.DataSource ?? string.Empty;
+        public override string DataSource => _internal?.DataSource;
 
         /// <summary>
         /// Gets the version of the current server
         /// </summary>
-        public override string ServerVersion => _internal?.ServerVersion ?? string.Empty;
+        public override string ServerVersion => _internal?.ServerVersion;
 
         /// <summary>
         /// Indicates the state of the <see cref="AseConnection" /> during the most recent network operation 
@@ -580,6 +580,4 @@ namespace AdoNetCore.AseClient
     /// the TraceEnter and TraceExit events.</para>
     /// </remarks>
     public delegate void TraceExitEventHandler(AseConnection connection, object source, string method, object returnValue);
-
-
 }

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -135,21 +135,22 @@ namespace AdoNetCore.AseClient
             }
         }
 
-        /// <summary>
-        /// Starts a database transaction.
-        /// </summary>
-        /// <returns>An object representing the new transaction.</returns>
-        /// <remarks>
-        /// <para>This command maps to the SQL Server implementation of BEGIN TRANSACTION.</para>
-        /// <para>You must explicitly commit or roll back the transaction using the <see cref="AseTransaction.Commit" /> 
-        /// or <see cref="AseTransaction.Rollback" /> method. To make sure that the .NET Framework Data Provider for ASE 
-        /// transaction management model performs correctly, avoid using other transaction management models, such as the 
-        /// one provided by ASE.</para>
-        /// <para>If you do not specify an isolation level, the default isolation level is used. To specify an isolation 
-        /// level with the <see cref="BeginTransaction()" /> method, use the overload that takes the iso parameter 
-        /// (<see cref="BeginTransaction(IsolationLevel)" />).</para>
+        /// <summary>		
+        /// Starts a database transaction.		
+        /// </summary>		
+        /// <param name="isolationLevel">The isolation level under which the transaction should run.</param>		
+        /// <returns>An object representing the new transaction.</returns>		
+        /// <remarks>		
+        /// <para>This command maps to the SQL Server implementation of BEGIN TRANSACTION.</para>		
+        /// <para>You must explicitly commit or roll back the transaction using the <see cref="AseTransaction.Commit" /> 		
+        /// or <see cref="AseTransaction.Rollback" /> method. To make sure that the .NET Framework Data Provider for ASE 		
+        /// transaction management model performs correctly, avoid using other transaction management models, such as the 		
+        /// one provided by ASE.</para>		
+        /// <para>If you do not specify an isolation level, the default isolation level is used. To specify an isolation 		
+        /// level with the <see cref="BeginTransaction" /> method, use the overload that takes the iso parameter 		
+        /// (<see cref="BeginTransaction(IsolationLevel)" />).</para>		
         /// </remarks>
-        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        public new AseTransaction BeginTransaction(IsolationLevel isolationLevel = IsolationLevel.Unspecified)
         {
             if (_isDisposed)
             {
@@ -157,9 +158,14 @@ namespace AdoNetCore.AseClient
             }
 
             Open();
-            var t = new AseTransaction(this);
+            var t = new AseTransaction(this, isolationLevel);
             t.Begin();
             return t;
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            return BeginTransaction(isolationLevel);
         }
 
         /// <summary>
@@ -211,7 +217,7 @@ namespace AdoNetCore.AseClient
         /// Creates and returns an <see cref="AseCommand" /> object associated with the <see cref="AseConnection" />.
         /// </summary>
         /// <returns>An <see cref="AseCommand" /> object.</returns>
-        protected override DbCommand CreateDbCommand()
+        public new AseCommand CreateCommand()
         {
             if (_isDisposed)
             {
@@ -221,6 +227,11 @@ namespace AdoNetCore.AseClient
             var aseCommand = new AseCommand(this) { NamedParameters = NamedParameters };
 
             return aseCommand;
+        }
+
+        protected override DbCommand CreateDbCommand()
+        {
+            return CreateCommand();
         }
 
         /// <summary>
@@ -301,11 +312,17 @@ namespace AdoNetCore.AseClient
         /// statement or the <see cref="ChangeDatabase(string)" /> method, an informational message is sent and 
         /// the property is updated automatically.
         /// </remarks>
-        public override string Database => _internal?.Database;
+        public override string Database => _internal?.Database ?? string.Empty;
 
-        public override string DataSource { get; }
+        /// <summary>
+        /// Gets the name of the current server
+        /// </summary>
+        public override string DataSource => _internal?.DataSource ?? string.Empty;
 
-        public override string ServerVersion { get; }
+        /// <summary>
+        /// Gets the version of the current server
+        /// </summary>
+        public override string ServerVersion => _internal?.ServerVersion ?? string.Empty;
 
         /// <summary>
         /// Indicates the state of the <see cref="AseConnection" /> during the most recent network operation 

--- a/src/AdoNetCore.AseClient/AseDataReader.cs
+++ b/src/AdoNetCore.AseClient/AseDataReader.cs
@@ -165,19 +165,19 @@ namespace AdoNetCore.AseClient
 
         public override object this[string name] => GetValue(GetOrdinal(name));
 
-#if NETCOREAPP2_0 || NET45
-        public override void Close() { }
-#else
+#if NETCORE_OLD
         public void Close() { }
+#else
+        public override void Close() { }
 #endif
 
-#if NETCOREAPP2_0 || NET45
-        public override DataTable GetSchemaTable()
+#if NETCORE_OLD
+        public DataTable GetSchemaTable()
         {
             throw new NotImplementedException();
         }
 #else
-        public DataTable GetSchemaTable()
+        public override DataTable GetSchemaTable()
         {
             throw new NotImplementedException();
         }

--- a/src/AdoNetCore.AseClient/AseDataReader.cs
+++ b/src/AdoNetCore.AseClient/AseDataReader.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections;
 using System.Data;
+using System.Data.Common;
 using AdoNetCore.AseClient.Internal;
 
 namespace AdoNetCore.AseClient
 {
-    public sealed class AseDataReader : IDataReader
+    public sealed class AseDataReader : DbDataReader
     {
         //todo: needs unit tests, feels a bit flimsy
         private readonly TableResult[] _results;
@@ -17,84 +19,84 @@ namespace AdoNetCore.AseClient
             NextResult();
         }
 
-        public bool GetBoolean(int i)
+        public override bool GetBoolean(int i)
         {
             throw new NotImplementedException();
         }
 
-        public byte GetByte(int i)
+        public override byte GetByte(int i)
         {
             throw new NotImplementedException();
         }
 
-        public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length)
+        public override long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length)
         {
             throw new NotImplementedException();
         }
 
-        public char GetChar(int i)
+        public override char GetChar(int i)
         {
             throw new NotImplementedException();
         }
 
-        public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length)
+        public override long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length)
         {
             throw new NotImplementedException();
         }
 
-        public IDataReader GetData(int i)
+        public override string GetDataTypeName(int i)
         {
             throw new NotImplementedException();
         }
 
-        public string GetDataTypeName(int i)
+        public override IEnumerator GetEnumerator()
         {
             throw new NotImplementedException();
         }
 
-        public DateTime GetDateTime(int i)
+        public override DateTime GetDateTime(int i)
         {
             throw new NotImplementedException();
         }
 
-        public decimal GetDecimal(int i)
+        public override decimal GetDecimal(int i)
         {
             throw new NotImplementedException();
         }
 
-        public double GetDouble(int i)
+        public override double GetDouble(int i)
         {
             throw new NotImplementedException();
         }
 
-        public Type GetFieldType(int i) => typeof(object);
+        public override Type GetFieldType(int i) => typeof(object);
 
-        public float GetFloat(int i)
+        public override float GetFloat(int i)
         {
             throw new NotImplementedException();
         }
 
-        public Guid GetGuid(int i)
+        public override Guid GetGuid(int i)
         {
             throw new NotImplementedException();
         }
 
-        public short GetInt16(int i)
+        public override short GetInt16(int i)
         {
             throw new NotImplementedException();
         }
 
-        public int GetInt32(int i)
+        public override int GetInt32(int i)
         {
             throw new NotImplementedException();
         }
 
-        public long GetInt64(int i)
+        public override long GetInt64(int i)
         {
             throw new NotImplementedException();
         }
 
-        public string GetName(int i)
+        public override string GetName(int i)
         {
             if (_currentResult >= 0
                 && _currentResult < _results.Length
@@ -106,7 +108,7 @@ namespace AdoNetCore.AseClient
             throw new ArgumentException();
         }
 
-        public int GetOrdinal(string name)
+        public override int GetOrdinal(string name)
         {
             if (_currentResult >= 0 && _currentResult < _results.Length)
             {
@@ -123,12 +125,12 @@ namespace AdoNetCore.AseClient
             throw new ArgumentException();
         }
 
-        public string GetString(int i)
+        public override string GetString(int i)
         {
             throw new NotImplementedException();
         }
 
-        public object GetValue(int i)
+        public override object GetValue(int i)
         {
             if (_currentResult >= 0
                 && _currentResult < _results.Length
@@ -143,37 +145,45 @@ namespace AdoNetCore.AseClient
             throw new ArgumentOutOfRangeException();
         }
 
-        public int GetValues(object[] values)
+        public override int GetValues(object[] values)
         {
             throw new NotImplementedException();
         }
 
-        public bool IsDBNull(int i)
+        public override bool IsDBNull(int i)
         {
             throw new NotImplementedException();
         }
 
-        public int FieldCount => _currentResult >= 0 && _currentResult < _results.Length
+        public override int FieldCount => _currentResult >= 0 && _currentResult < _results.Length
             ? _results[_currentResult].Formats.Length
             : 0;
 
-        object IDataRecord.this[int i] => GetValue(i);
+        public override bool HasRows => _results.Length > 0;
 
-        object IDataRecord.this[string name] => GetValue(GetOrdinal(name));
-        
-        public void Dispose() { }
+        public override object this[int ordinal] => GetValue(ordinal);
 
-        public void Close()
+        public override object this[string name] => GetValue(GetOrdinal(name));
+
+#if NETCOREAPP2_0 || NET45
+        public override void Close() { }
+#else
+        public void Close() { }
+#endif
+
+#if NETCOREAPP2_0 || NET45
+        public override DataTable GetSchemaTable()
         {
             throw new NotImplementedException();
         }
-
+#else
         public DataTable GetSchemaTable()
         {
             throw new NotImplementedException();
         }
+#endif
 
-        public bool NextResult()
+        public override bool NextResult()
         {
             _currentResult++;
 
@@ -188,7 +198,7 @@ namespace AdoNetCore.AseClient
             }
         }
 
-        public bool Read()
+        public override bool Read()
         {
             if (_currentResult < 0)
             {
@@ -205,9 +215,9 @@ namespace AdoNetCore.AseClient
             return false;
         }
 
-        public int Depth => 0;
-        public bool IsClosed => _currentResult >= _results.Length;
-        public int RecordsAffected => _currentResult >= 0 && _currentResult < _results.Length
+        public override int Depth => 0;
+        public override bool IsClosed => _currentResult >= _results.Length;
+        public override int RecordsAffected => _currentResult >= 0 && _currentResult < _results.Length
             ? _results[_currentResult].Rows.Count
             : 0;
     }

--- a/src/AdoNetCore.AseClient/AseException.cs
+++ b/src/AdoNetCore.AseClient/AseException.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#if NETCOREAPP2_0 || NET45
+#if !NETCORE_OLD
 using System.Runtime.Serialization;
 #endif
 
@@ -8,14 +8,14 @@ namespace AdoNetCore.AseClient
     /// <summary>
     /// The exception that is thrown when ASE returns a warning or error. This class cannot be inherited.
     /// </summary>
-#if NETCOREAPP2_0 || NET45
+#if !NETCORE_OLD
     [Serializable]
 #endif
     public sealed class AseException :
-#if NETCOREAPP2_0 || NET45
-    SystemException
-#else
+#if NETCORE_OLD
     Exception
+#else
+    SystemException
 #endif
     {
         /// <summary>
@@ -107,7 +107,7 @@ namespace AdoNetCore.AseClient
             Errors = new AseErrorCollection(errors);
         }
 
-#if NETCOREAPP2_0 || NET45
+#if !NETCORE_OLD
         private AseException(SerializationInfo info, StreamingContext context) : base(info, context) {
             Errors = new AseErrorCollection(new AseError
             {

--- a/src/AdoNetCore.AseClient/AseInfoMessageEventArgs.cs
+++ b/src/AdoNetCore.AseClient/AseInfoMessageEventArgs.cs
@@ -7,6 +7,12 @@ namespace AdoNetCore.AseClient
     /// </summary>
     public sealed class AseInfoMessageEventArgs : EventArgs
     {
+        public AseInfoMessageEventArgs(AseErrorCollection errors, string message)
+        {
+            Message = message;
+            Errors = errors;
+        }
+
         /// <summary>
         /// A collection of the actual error objects returned by the server.
         /// </summary>

--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -255,17 +255,12 @@ namespace AdoNetCore.AseClient
         /// </summary>
         public override string SourceColumn { get; set; }
 
-        //public override DataRowVersion SourceVersion { get; set; }
-
         public override bool SourceColumnNullMapping { get; set; }
 
-#if NETCOREAPP2_0 || NET45
-        /// <summary>
-        /// Not supported yet. .NET Core 2.0 dependency.
-        /// </summary>
-        public override DataRowVersion SourceVersion { get; set; }
-#else
+#if NETCORE_OLD
         public DataRowVersion SourceVersion { get; set; }
+#else
+        public override DataRowVersion SourceVersion { get; set; }
 #endif
         /// <summary>
         /// Gets or sets the value of the parameter.

--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -297,10 +297,10 @@ namespace AdoNetCore.AseClient
         /// passing it to the database, use the <see cref="System.Math" /> class that is part of the System namespace prior to assigning a value to 
         /// the parameter's <see cref="Value" /> property.</para>
         /// </remarks>
-#if NETCOREAPP2_0
-        public override byte Precision { get; set; }
-#else
+#if NET45
         public byte Precision { get; set; }
+#else
+        public override byte Precision { get; set; }
 #endif
 
         /// <summary>
@@ -318,10 +318,10 @@ namespace AdoNetCore.AseClient
         /// passing it to the database, use the <see cref="System.Math" /> class that is part of the System namespace prior to assigning a value to 
         /// the parameter's <see cref="Value" /> property.</para>
         /// </remarks>
-#if NETCOREAPP2_0
-        public override byte Scale { get; set; }
-#else
+#if NET45
         public byte Scale { get; set; }
+#else
+        public override byte Scale { get; set; }
 #endif
 
         /// <summary>

--- a/src/AdoNetCore.AseClient/AseParameterCollection.cs
+++ b/src/AdoNetCore.AseClient/AseParameterCollection.cs
@@ -49,16 +49,16 @@ namespace AdoNetCore.AseClient
             }
         }
 
-#if NETCOREAPP2_0 || NET45
-        public override bool IsFixedSize => ((IList)_parameters).IsFixedSize;
-#else
+#if NETCORE_OLD
         public bool IsFixedSize => ((IList)_parameters).IsFixedSize;
+#else
+        public override bool IsFixedSize => ((IList)_parameters).IsFixedSize;
 #endif
 
-#if NETCOREAPP2_0 || NET45
-        public override bool IsReadOnly => ((IList)_parameters).IsReadOnly;
-#else
+#if NETCORE_OLD
         public bool IsReadOnly => ((IList)_parameters).IsReadOnly;
+#else
+        public override bool IsReadOnly => ((IList)_parameters).IsReadOnly;
 #endif
 
         /// <summary>
@@ -66,10 +66,10 @@ namespace AdoNetCore.AseClient
         /// </summary>
         public override int Count => _parameters.Count;
 
-#if NETCOREAPP2_0 || NET45
-        public override bool IsSynchronized => ((IList)_parameters).IsSynchronized;
-#else
+#if NETCORE_OLD
         public bool IsSynchronized => ((IList)_parameters).IsSynchronized;
+#else
+        public override bool IsSynchronized => ((IList)_parameters).IsSynchronized;
 #endif
 
         public override object SyncRoot => ((IList)_parameters).SyncRoot;

--- a/src/AdoNetCore.AseClient/AseParameterCollection.cs
+++ b/src/AdoNetCore.AseClient/AseParameterCollection.cs
@@ -12,7 +12,7 @@ namespace AdoNetCore.AseClient
     /// This class cannot be inherited.
     /// </summary>
     [DebuggerDisplay("Count = {" + nameof(Count) + "}")]
-    public sealed class AseParameterCollection : DbParameterCollection//IDataParameterCollection
+    public sealed class AseParameterCollection : DbParameterCollection
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly List<AseParameter> _parameters;
@@ -78,6 +78,7 @@ namespace AdoNetCore.AseClient
         {
             return _parameters[index];
         }
+
         protected override void SetParameter(int index, DbParameter value)
         {
             _parameters[index] = (AseParameter)value;
@@ -114,6 +115,18 @@ namespace AdoNetCore.AseClient
         public override bool Contains(object value)
         {
             return IndexOf(value) >= 0;
+        }
+
+        public new AseParameter this[string parameterName]
+        {
+            get => (AseParameter) GetParameter(parameterName);
+            set => SetParameter(parameterName, value);
+        }
+
+        public new AseParameter this[int index]
+        {
+            get => (AseParameter) GetParameter(index);
+            set => SetParameter(index, value);
         }
 
         /// <summary>

--- a/src/AdoNetCore.AseClient/AseParameterCollection.cs
+++ b/src/AdoNetCore.AseClient/AseParameterCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics;
 
 namespace AdoNetCore.AseClient
@@ -11,7 +12,7 @@ namespace AdoNetCore.AseClient
     /// This class cannot be inherited.
     /// </summary>
     [DebuggerDisplay("Count = {" + nameof(Count) + "}")]
-    public sealed class AseParameterCollection : IDataParameterCollection
+    public sealed class AseParameterCollection : DbParameterCollection//IDataParameterCollection
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly List<AseParameter> _parameters;
@@ -48,20 +49,39 @@ namespace AdoNetCore.AseClient
             }
         }
 
+#if NETCOREAPP2_0 || NET45
+        public override bool IsFixedSize => ((IList)_parameters).IsFixedSize;
+#else
         public bool IsFixedSize => ((IList)_parameters).IsFixedSize;
+#endif
 
+#if NETCOREAPP2_0 || NET45
+        public override bool IsReadOnly => ((IList)_parameters).IsReadOnly;
+#else
         public bool IsReadOnly => ((IList)_parameters).IsReadOnly;
+#endif
 
         /// <summary>
         /// Represents the number of <see cref="AseParameter" /> objects in the collection.
         /// </summary>
-        public int Count => _parameters.Count;
+        public override int Count => _parameters.Count;
 
+#if NETCOREAPP2_0 || NET45
+        public override bool IsSynchronized => ((IList)_parameters).IsSynchronized;
+#else
         public bool IsSynchronized => ((IList)_parameters).IsSynchronized;
+#endif
 
-        public object SyncRoot => ((IList)_parameters).SyncRoot;
+        public override object SyncRoot => ((IList)_parameters).SyncRoot;
 
-        public object this[int index] { get => ((IList)_parameters)[index]; set => ((IList)_parameters)[index] = value; }
+        protected override DbParameter GetParameter(int index)
+        {
+            return _parameters[index];
+        }
+        protected override void SetParameter(int index, DbParameter value)
+        {
+            _parameters[index] = (AseParameter)value;
+        }
 
         public AseParameterCollection() 
         {
@@ -71,7 +91,7 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// Removes all items from the collection.
         /// </summary>
-        public void Clear() 
+        public override void Clear() 
         {
             _parameters.Clear();
         }
@@ -81,7 +101,7 @@ namespace AdoNetCore.AseClient
         /// </summary>
         /// <param name="parameterName">The name of the parameter.</param>
         /// <returns><b>true</b> if the <see cref="AseParameterCollection" /> contains the value; otherwise <b>false</b>.</returns>
-        public bool Contains(string parameterName)
+        public override bool Contains(string parameterName)
         {
             return IndexOf(parameterName) >= 0;
         }
@@ -91,7 +111,7 @@ namespace AdoNetCore.AseClient
         /// </summary>
         /// <param name="value">The <see cref="AseParameter" />.</param>
         /// <returns><b>true</b> if the <see cref="AseParameterCollection" /> contains the value; otherwise <b>false</b>.</returns>
-        public bool Contains(object value)
+        public override bool Contains(object value)
         {
             return IndexOf(value) >= 0;
         }
@@ -105,43 +125,35 @@ namespace AdoNetCore.AseClient
         /// <para>The <i>parameterName</i> is used to look up the index value in the underlying <see cref="AseParameterCollection" />. 
         /// If the <i>parameterName</i> is not valid, an <see cref="IndexOutOfRangeException" /> will be thrown.</para>
         /// </remarks>
-        object IDataParameterCollection.this[string parameterName]
+        protected override DbParameter GetParameter(string parameterName)
         {
-            get => this[parameterName];
-            set => this[parameterName] = value as AseParameter;
+            var index = IndexOf(parameterName);
+            if (index < 0)
+            {
+                return null;
+            }
+            return _parameters[index];
         }
 
         /// <summary>
-        /// Gets the <see cref="AseParameter" /> with the specified name.
+        /// Sets the <see cref="AseParameter" /> with the specified name.
         /// </summary>
         /// <param name="parameterName">The name of the parameter.</param>
-        /// <returns>The <see cref="AseParameter" /> with the specified name.</returns>
+        /// <param name="value">The parameter.</param>
         /// <remarks>
         /// <para>The <i>parameterName</i> is used to look up the index value in the underlying <see cref="AseParameterCollection" />. 
         /// If the <i>parameterName</i> is not valid, an <see cref="IndexOutOfRangeException" /> will be thrown.</para>
         /// </remarks>
-        public AseParameter this[string parameterName]
+        protected override void SetParameter(string parameterName, DbParameter value)
         {
-            get
+            var index = IndexOf(parameterName);
+            if (index < 0)
             {
-                var index = IndexOf(parameterName);
-                if (index < 0)
-                {
-                    return null;
-                }
-                return _parameters[index];
+                Add(value);
             }
-            set
+            else
             {
-                var index = IndexOf(parameterName);
-                if (index < 0)
-                {
-                    Add(value);
-                }
-                else
-                {
-                    _parameters[index] = value;
-                }
+                _parameters[index] = (AseParameter) value;
             }
         }
 
@@ -237,13 +249,15 @@ namespace AdoNetCore.AseClient
         }
 
         /// <summary>
-        /// Adds an <see cref="AseParameter" /> to the <see cref="AseParameterCollection" />.
+        /// Adds an <see cref="Array"/> of <see cref="AseParameter"/> to the <see cref="AseParameterCollection"/>.
         /// </summary>
-        /// <param name="parameter">The <see cref="AseParameter" /> to add.</param>
-        /// <returns>A new <see cref="AseParameter" /> object.</returns>
-        public AseParameter Add(object parameter) 
+        /// <param name="values"></param>
+        public override void AddRange(Array values)
         {
-            return Add(parameter as AseParameter);
+            foreach (var obj in values)
+            {
+                Add(obj);
+            }
         }
 
         /// <summary>
@@ -259,14 +273,19 @@ namespace AdoNetCore.AseClient
             return Add(parameter);
         }
 
-        int IList.Add(object value)
+        /// <summary>
+        /// Adds an <see cref="AseParameter" /> to the <see cref="AseParameterCollection" />.
+        /// </summary>
+        /// <param name="value">The <see cref="AseParameter" /> to add.</param>
+        /// <returns>The index of the <see cref="AseParameter" /> object.</returns>
+        public override int Add(object value)
         {
-            if(value is AseParameter p)
+            if (value is AseParameter p)
             {
-                 return ((IList)_parameters).Add(p);
+                return ((IList)_parameters).Add(p);
             }
             return -1;
-        }        
+        }
 
         /// <summary>
         /// Gets the location of the specified <see cref="AseParameter" /> with the specified name.
@@ -274,7 +293,7 @@ namespace AdoNetCore.AseClient
         /// <param name="parameterName">The name of the parameter.</param>
         /// <returns>The zero-based location of the specified <see cref="AseParameter" /> with the specified case-sensitive name. 
         /// Returns -1 when the object does not exist in the <see cref="AseParameterCollection" />.</returns>
-        public int IndexOf(string parameterName)
+        public override int IndexOf(string parameterName)
         {
             if (string.IsNullOrWhiteSpace(parameterName))
             {
@@ -298,7 +317,7 @@ namespace AdoNetCore.AseClient
         /// <param name="value">The <see cref="AseParameter" />.</param>
         /// <returns>The zero-based location of the specified <see cref="AseParameter" />. 
         /// Returns -1 when the object does not exist in the <see cref="AseParameterCollection" />.</returns>
-        public int IndexOf(object value)
+        public override int IndexOf(object value)
         {
             if(value is AseParameter p) 
             {
@@ -319,7 +338,7 @@ namespace AdoNetCore.AseClient
         /// </summary>
         /// <param name="index">The zero-based index where the parameter is to be inserted within the collection.</param>
         /// <param name="value">The <see cref="AseParameter" /> object to add to the collection.</param>
-        public void Insert(int index, object value)
+        public override void Insert(int index, object value)
         {
             ((IList)_parameters).Insert(index, value);
         }
@@ -328,7 +347,7 @@ namespace AdoNetCore.AseClient
         /// Removes the <see cref="AseParameter" /> from the <see cref="AseParameterCollection" />.
         /// </summary>
         /// <param name="value">The <see cref="AseParameter" /> object to remove from the collection.</param>
-        public void Remove(object value)
+        public override void Remove(object value)
         {
             ((IList)_parameters).Remove(value);
         }
@@ -337,7 +356,7 @@ namespace AdoNetCore.AseClient
         /// Removes the <see cref="AseParameter" /> from the <see cref="AseParameterCollection" /> at the specified parameter name.
         /// </summary>
         /// <param name="parameterName">The name of the parameter to remove.</param>
-        public void RemoveAt(string parameterName)
+        public override void RemoveAt(string parameterName)
         {
             var index = IndexOf(parameterName);
             if (index < 0)
@@ -352,7 +371,7 @@ namespace AdoNetCore.AseClient
         /// Removes the <see cref="AseParameter" /> from the <see cref="AseParameterCollection" /> at the specified index.
         /// </summary>
         /// <param name="index">The zero-based index of the parameter to remove.</param>
-        public void RemoveAt(int index)
+        public override void RemoveAt(int index)
         {
             _parameters.RemoveAt(index);
         }
@@ -362,7 +381,7 @@ namespace AdoNetCore.AseClient
         /// </summary>
         /// <param name="array">The array into which to copy the AseParameter objects.</param>
         /// <param name="index">The starting index of the array.</param>
-        public void CopyTo(Array array, int index)
+        public override void CopyTo(Array array, int index)
         {
             ((IList)_parameters).CopyTo(array, index);
         }
@@ -371,7 +390,7 @@ namespace AdoNetCore.AseClient
         /// Enumerates the <see cref="AseParameter" /> objects.
         /// </summary>
         /// <returns>The <see cref="AseParameter" /> objects.</returns>
-        public IEnumerator GetEnumerator()
+        public override IEnumerator GetEnumerator()
         {
             return ((IList)_parameters).GetEnumerator();
         }

--- a/src/AdoNetCore.AseClient/AseTransaction.cs
+++ b/src/AdoNetCore.AseClient/AseTransaction.cs
@@ -58,6 +58,7 @@ namespace AdoNetCore.AseClient
                 {
                     throw new ObjectDisposedException(nameof(AseTransaction));
                 }
+
                 return (AseConnection)_connection;
             }
         }

--- a/src/AdoNetCore.AseClient/AseTransaction.cs
+++ b/src/AdoNetCore.AseClient/AseTransaction.cs
@@ -29,11 +29,17 @@ namespace AdoNetCore.AseClient
         /// <param name="connection">The <see cref="AseConnection"/> that initiated this <see cref="AseTransaction"/>.</param>
         /// <param name="isolationLevel">The <see cref="IsolationLevel"/> to apply to the transaction.</param>
         /// <exception cref="ArgumentException">Thrown in the provided <paramref name="isolationLevel"/> is not an isolation level supported by ASE.</exception>
-        internal AseTransaction(IDbConnection connection, IsolationLevel isolationLevel = IsolationLevel.ReadCommitted)
+        internal AseTransaction(IDbConnection connection, IsolationLevel isolationLevel = IsolationLevel.Unspecified)
         {
+            //default
+            if (isolationLevel == IsolationLevel.Unspecified)
+            {
+                isolationLevel = IsolationLevel.ReadCommitted;
+            }
+
             if (!IsolationLevelMap.ContainsKey(isolationLevel))
             {
-                throw new ArgumentException("Isolation level is unsupported by ASE", nameof(isolationLevel));
+                throw new ArgumentException($"Isolation level '{isolationLevel}' is not supported", nameof(isolationLevel));
             }
             _connection = connection;
             _isolationLevel = isolationLevel;
@@ -44,7 +50,7 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// The <see cref="AseConnection"/> that initiated this <see cref="AseTransaction"/>.
         /// </summary>
-        protected override DbConnection DbConnection
+        public new AseConnection Connection
         {
             get
             {
@@ -55,6 +61,8 @@ namespace AdoNetCore.AseClient
                 return (AseConnection)_connection;
             }
         }
+
+        protected override DbConnection DbConnection => Connection;
 
         /// <summary>
         /// The <see cref="IsolationLevel"/> to apply to the transaction.

--- a/src/AdoNetCore.AseClient/AseTransaction.cs
+++ b/src/AdoNetCore.AseClient/AseTransaction.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 
 namespace AdoNetCore.AseClient
 {
     /// <summary>
     /// Represents a transaction against a SAP ASE database. This class cannot be inherited
     /// </summary>
-    public sealed class AseTransaction : IDbTransaction
+    public sealed class AseTransaction : DbTransaction
     {
         private static readonly Dictionary<IsolationLevel, int> IsolationLevelMap = new Dictionary<IsolationLevel, int>
         {
@@ -43,12 +44,7 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// The <see cref="AseConnection"/> that initiated this <see cref="AseTransaction"/>.
         /// </summary>
-        public AseConnection Connection => _connection as AseConnection;
-
-        /// <summary>
-        /// The <see cref="AseConnection"/> that initiated this <see cref="AseTransaction"/>.
-        /// </summary>
-        IDbConnection IDbTransaction.Connection
+        protected override DbConnection DbConnection
         {
             get
             {
@@ -56,15 +52,14 @@ namespace AdoNetCore.AseClient
                 {
                     throw new ObjectDisposedException(nameof(AseTransaction));
                 }
-
-                return _connection;
+                return (AseConnection)_connection;
             }
         }
 
         /// <summary>
         /// The <see cref="IsolationLevel"/> to apply to the transaction.
         /// </summary>
-        public IsolationLevel IsolationLevel
+        public override IsolationLevel IsolationLevel
         {
             get
             {
@@ -107,7 +102,7 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// Commits the transaction.
         /// </summary>
-        public void Commit()
+        public override void Commit()
         {
             if (_isDisposed)
             {
@@ -133,7 +128,7 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// Disposes of the <see cref="AseTransaction"/>. Will implicitly rolls back the transaction if it has not already been rolled back or committed.
         /// </summary>
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
             if (_isDisposed)
             {
@@ -148,7 +143,7 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// Rolls back the transaction.
         /// </summary>
-        public void Rollback()
+        public override void Rollback()
         {
             if (_isDisposed)
             {

--- a/src/AdoNetCore.AseClient/Enum/BufferType.cs
+++ b/src/AdoNetCore.AseClient/Enum/BufferType.cs
@@ -43,7 +43,6 @@ namespace AdoNetCore.AseClient.Enum
         /// The buffer contains a non-expedited attention request.
         /// Refer: 12. Cancel Protocol
         /// </summary>
-        [Obsolete]
         TDS_BUF_ATTN = 6,
         /// <summary>
         /// The buffer contains bulk binary data.

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -59,14 +59,12 @@ namespace AdoNetCore.AseClient.Interface
 
         /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>
-        /// TODO: change return type to AseDataReader
         /// </summary>
         DbDataReader ExecuteReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
 
         /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>,
         /// but the result is wrapped in a Task to allow the caller to check IsCanceled
-        /// TODO: change return type to AseDataReader
         /// </summary>
         Task<DbDataReader> ExecuteReaderTaskRunnable(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
 

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Threading.Tasks;
 
 namespace AdoNetCore.AseClient.Interface
 {
@@ -37,6 +38,13 @@ namespace AdoNetCore.AseClient.Interface
         /// Internal implementation of <see cref="IDbCommand.ExecuteNonQuery"/>
         /// </summary>
         int ExecuteNonQuery(AseCommand command, AseTransaction transaction);
+        
+        /// <summary>
+        /// Internal implementation of <see cref="IDbCommand.ExecuteNonQuery"/>,
+        /// but the result is wrapped in a Task to allow the caller to check IsCanceled
+        /// </summary>
+        Task<int> ExecuteNonQueryAsTask(AseCommand command, AseTransaction transaction);
+
 
         /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Data.Common;
 using System.Threading.Tasks;
 
 namespace AdoNetCore.AseClient.Interface
@@ -43,19 +44,28 @@ namespace AdoNetCore.AseClient.Interface
         /// Internal implementation of <see cref="IDbCommand.ExecuteNonQuery"/>,
         /// but the result is wrapped in a Task to allow the caller to check IsCanceled
         /// </summary>
-        Task<int> ExecuteNonQueryAsTask(AseCommand command, AseTransaction transaction);
+        Task<int> ExecuteNonQueryTaskRunnable(AseCommand command, AseTransaction transaction);
 
 
         /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>
         /// </summary>
-        AseDataReader ExecuteReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
+        DbDataReader ExecuteReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
+
+        /// <summary>
+        /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>,
+        /// but the result is wrapped in a Task to allow the caller to check IsCanceled
+        /// </summary>
+        Task<DbDataReader> ExecuteReaderTaskRunnable(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
 
         /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteScalar"/>
         /// </summary>
         object ExecuteScalar(AseCommand command, AseTransaction transaction);
 
+        /// <summary>
+        /// Cancel the currently running command
+        /// </summary>
         void Cancel();
 
         /// <summary>

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -48,6 +48,8 @@ namespace AdoNetCore.AseClient.Interface
         /// </summary>
         object ExecuteScalar(AseCommand command, AseTransaction transaction);
 
+        void Cancel();
+
         /// <summary>
         /// Set @@textsize, useful if the caller needs to select out very large text data
         /// </summary>

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -36,6 +36,16 @@ namespace AdoNetCore.AseClient.Interface
         string Database { get; }
 
         /// <summary>
+        /// Get the current connection/session's data source (server name/address)
+        /// </summary>
+        string DataSource { get; }
+
+        /// <summary>
+        /// Get the current connection/session's server version
+        /// </summary>
+        string ServerVersion { get; }
+
+        /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteNonQuery"/>
         /// </summary>
         int ExecuteNonQuery(AseCommand command, AseTransaction transaction);
@@ -49,12 +59,14 @@ namespace AdoNetCore.AseClient.Interface
 
         /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>
+        /// TODO: change return type to AseDataReader
         /// </summary>
         DbDataReader ExecuteReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
 
         /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>,
         /// but the result is wrapped in a Task to allow the caller to check IsCanceled
+        /// TODO: change return type to AseDataReader
         /// </summary>
         Task<DbDataReader> ExecuteReaderTaskRunnable(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
 

--- a/src/AdoNetCore.AseClient/Interface/IPacket.cs
+++ b/src/AdoNetCore.AseClient/Interface/IPacket.cs
@@ -8,6 +8,11 @@ namespace AdoNetCore.AseClient.Interface
     {
         BufferType Type { get; }
         /// <summary>
+        /// Status flags to send over the wire
+        /// If no flags to send, should equal BufferStatus.TDS_BUFSTAT_NONE
+        /// </summary>
+        BufferStatus Status { get; }
+        /// <summary>
         /// Write this packet to a stream, do not worry about packet chunking, that'll happen later
         /// </summary>
         /// <param name="stream">Stream to write to</param>

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
@@ -114,10 +114,13 @@ namespace AdoNetCore.AseClient.Internal
                     continue;
                 }
 
-                if (!_parameters.PingServer || connection.Ping())
+                if (_parameters.PingServer && !connection.Ping())
                 {
-                    return connection;
+                    RemoveAndReplace(connection);
+                    continue;
                 }
+
+                return connection;
             }
 
             Logger.Instance?.WriteLine($"{nameof(FetchIdlePooledConnection)} found no idle connection");

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
@@ -15,13 +15,14 @@ namespace AdoNetCore.AseClient.Internal
 
         public void Release(string connectionString, IInternalConnection connection)
         {
+            if (connection == null)
+            {
+                return; //essentially, it's released :)
+            }
+
             if (Pools.TryGetValue(connectionString, out var pool))
             {
                 pool.Release(connection);
-            }
-            else
-            {
-                throw new ArgumentException("No connection pool exists for that connection string");
             }
         }
     }

--- a/src/AdoNetCore.AseClient/Internal/Handler/DoneTokenHandler.cs
+++ b/src/AdoNetCore.AseClient/Internal/Handler/DoneTokenHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Token;
@@ -9,6 +10,7 @@ namespace AdoNetCore.AseClient.Internal.Handler
     {
         public TranState? TransactionState { get; private set; }
         public int RowsAffected { get; private set; }
+        public bool Canceled { get; private set; }
         
         private static readonly HashSet<TokenType> AllowedTypes = new HashSet<TokenType>
         {
@@ -33,6 +35,10 @@ namespace AdoNetCore.AseClient.Internal.Handler
                     {
                         Logger.Instance?.WriteLine($"  {t.TransactionState}");
                         TransactionState = t.TransactionState;
+                    }
+                    if (t.Status.HasFlag(DoneToken.DoneStatus.TDS_DONE_ATTN))
+                    {
+                        Canceled = true;
                     }
                     if (t.Status.HasFlag(DoneToken.DoneStatus.TDS_DONE_COUNT))
                     {

--- a/src/AdoNetCore.AseClient/Internal/Handler/LoginTokenHandler.cs
+++ b/src/AdoNetCore.AseClient/Internal/Handler/LoginTokenHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using AdoNetCore.AseClient.Enum;
+﻿using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Token;
 
@@ -8,6 +7,7 @@ namespace AdoNetCore.AseClient.Internal.Handler
     internal class LoginTokenHandler : ITokenHandler
     {
         public bool ReceivedAck { get; private set; }
+        public LoginAckToken Token { get; private set; }
 
         public bool CanHandle(TokenType type)
         {
@@ -20,6 +20,8 @@ namespace AdoNetCore.AseClient.Internal.Handler
             {
                 case LoginAckToken t:
                     ReceivedAck = true;
+                    Token = t;
+
                     if (t.Status == LoginAckToken.LoginStatus.TDS_LOG_FAIL)
                     {
                         throw new AseException("Login failed.");

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -180,7 +180,7 @@ namespace AdoNetCore.AseClient.Internal
 
         public string Database => _environment.Database;
         public string DataSource => $"{_parameters.Server},{_parameters.Port}";
-        public string ServerVersion { get; private set; } = string.Empty;
+        public string ServerVersion { get; private set; }
 
         private void InternalExecuteAsync(AseCommand command, AseTransaction transaction, TaskCompletionSource<int> rowsAffectedSource = null, TaskCompletionSource<DbDataReader> readerSource = null)
         {

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -118,6 +118,8 @@ namespace AdoNetCore.AseClient.Internal
                 throw new InvalidOperationException("No login ack found");
             }
 
+            ServerVersion = ackHandler.Token.ProgramVersion;
+
             Created = DateTime.UtcNow;
             SetState(InternalConnectionState.Ready);
         }
@@ -177,6 +179,8 @@ namespace AdoNetCore.AseClient.Internal
         }
 
         public string Database => _environment.Database;
+        public string DataSource => $"{_parameters.Server},{_parameters.Port}";
+        public string ServerVersion { get; private set; } = string.Empty;
 
         private void InternalExecuteAsync(AseCommand command, AseTransaction transaction, TaskCompletionSource<int> rowsAffectedSource = null, TaskCompletionSource<DbDataReader> readerSource = null)
         {

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -198,6 +198,7 @@ namespace AdoNetCore.AseClient.Internal
 
         public void Cancel()
         {
+            Logger.Instance?.WriteLine($"Canceling...");
             SendPacket(new AttentionPacket());
         }
 

--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -3,9 +3,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-#if NET45
-using System.Threading.Tasks;
-#endif
 using AdoNetCore.AseClient.Interface;
 
 namespace AdoNetCore.AseClient.Internal

--- a/src/AdoNetCore.AseClient/Internal/Logger.cs
+++ b/src/AdoNetCore.AseClient/Internal/Logger.cs
@@ -18,13 +18,14 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
-        public static void Enable(bool toConsole = true, bool toDebug = false)
+        public static void Enable(bool toConsole = true, bool toDebug = false, bool timestamps = false)
         {
 #if DEBUG
             _instance = new Logger
             {
                 ToConsole = toConsole,
-                ToDebug = toDebug
+                ToDebug = toDebug,
+                Timestamps = timestamps
             };
 #endif
         }
@@ -35,9 +36,15 @@ namespace AdoNetCore.AseClient.Internal
         }
 
         private bool ToConsole { get; set; } = true;
-        private bool ToDebug { get; set; } = false;
+        private bool ToDebug { get; set; }
+        private bool Timestamps { get; set; } = true;
+
+        private bool _lineStart = true;
 
         private Logger() { }
+
+        private string Timestamp => _lineStart && Timestamps ? DateTime.UtcNow.ToString("[yyyy-MM-dd HH:mm:ss] ") : string.Empty;
+
 
         public void WriteLine()
         {
@@ -47,14 +54,18 @@ namespace AdoNetCore.AseClient.Internal
 
         public void WriteLine(string line)
         {
-            if (ToConsole) Console.WriteLine(line);
-            if (ToDebug) Debug.WriteLine(line);
+            var formatted = $"{Timestamp}{line}";
+            if (ToConsole) Console.WriteLine(formatted);
+            if (ToDebug) Debug.WriteLine(formatted);
+            _lineStart = true;
         }
 
         public void Write(string value)
         {
-            if(ToConsole) Console.Write(value);
-            if(ToDebug) Debug.Write(value);
+            var formatted = $"{Timestamp}{value}";
+            if (ToConsole) Console.Write(formatted);
+            if(ToDebug) Debug.Write(formatted);
+            _lineStart = false;
         }
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/RegularSocket.cs
+++ b/src/AdoNetCore.AseClient/Internal/RegularSocket.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Sockets;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
+using AdoNetCore.AseClient.Token;
 
 namespace AdoNetCore.AseClient.Internal
 {
@@ -10,6 +11,7 @@ namespace AdoNetCore.AseClient.Internal
     {
         private readonly Socket _inner;
         private readonly ITokenParser _parser;
+        private readonly bool _hexDump = false;
 
         public DateTime LastActive { get; private set; }
 
@@ -24,37 +26,63 @@ namespace AdoNetCore.AseClient.Internal
             _inner.Dispose();
         }
 
-        private byte[] HeaderTemplate(BufferType type) => new byte[]
-        {
-            (byte) type, 0, 0, 0,
-            0, 0, 0, 0
-        };
+        private byte[] HeaderTemplate(BufferType type) => new byte[] { (byte) type, 0, 0, 0, 0, 0, 0, 0 };
+        private readonly object _sendMutex = new object();
 
         public void SendPacket(IPacket packet, DbEnvironment env)
         {
-            using (var ms = new MemoryStream())
+            lock (_sendMutex)
             {
-                packet.Write(ms, env.Encoding);
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                while (ms.Position < ms.Length)
+                try
                 {
-                    //split into chunks and send over the wire
-                    var buffer = new byte[env.PacketSize];
-                    var template = HeaderTemplate(packet.Type);
-                    Array.Copy(template, buffer, template.Length);
-                    var copied = ms.Read(buffer, template.Length, buffer.Length - template.Length);
-                    var chunkLength = template.Length + copied;
-                    buffer[1] = (byte)((ms.Position >= ms.Length ? BufferStatus.TDS_BUFSTAT_EOM : BufferStatus.TDS_BUFSTAT_NONE) | packet.Status);
-                    buffer[2] = (byte)(chunkLength >> 8);
-                    buffer[3] = (byte)chunkLength;
+                    using (var ms = new MemoryStream())
+                    {
+                        packet.Write(ms, env.Encoding);
 
-                    _inner.EnsureSend(buffer, 0, chunkLength);
+                        ms.Seek(0, SeekOrigin.Begin);
+
+                        if (ms.Length == 0)
+                        {
+                            //eg for cancel tokens
+                            SendJustHeader(packet);
+                            return;
+                        }
+
+                        while (ms.Position < ms.Length)
+                        {
+                            //split into chunks and send over the wire
+                            var buffer = new byte[env.PacketSize];
+                            var template = HeaderTemplate(packet.Type);
+                            Array.Copy(template, buffer, template.Length);
+                            var copied = ms.Read(buffer, template.Length, buffer.Length - template.Length);
+                            var chunkLength = template.Length + copied;
+                            buffer[1] = (byte) ((ms.Position >= ms.Length ? BufferStatus.TDS_BUFSTAT_EOM : BufferStatus.TDS_BUFSTAT_NONE) | packet.Status);
+                            buffer[2] = (byte) (chunkLength >> 8);
+                            buffer[3] = (byte) chunkLength;
+
+                            DumpBytes(buffer, chunkLength);
+
+                            _inner.EnsureSend(buffer, 0, chunkLength);
+                        }
+                    }
                 }
-
-                LastActive = DateTime.UtcNow;
+                finally
+                {
+                    LastActive = DateTime.UtcNow;
+                }
             }
+        }
+
+        private void SendJustHeader(IPacket packet)
+        {
+            var buffer = HeaderTemplate(packet.Type);
+            buffer[1] = (byte) (BufferStatus.TDS_BUFSTAT_EOM | packet.Status);
+            buffer[2] = (byte) (buffer.Length >> 8);
+            buffer[3] = (byte) buffer.Length;
+
+            DumpBytes(buffer);
+
+            _inner.EnsureSend(buffer, 0, buffer.Length);
         }
 
         public IToken[] ReceiveTokens(DbEnvironment env)
@@ -72,7 +100,7 @@ namespace AdoNetCore.AseClient.Internal
                     ms.Write(buffer, env.HeaderSize, length - env.HeaderSize);
 
                     //" If TDS_BUFSTAT_ATTNACK not also TDS_BUFSTAT_EOM, continue reading packets until TDS_BUFSTAT_EOM."
-                    canceled = bufferStatus.HasFlag(BufferStatus.TDS_BUFSTAT_ATTNACK);
+                    canceled = bufferStatus.HasFlag(BufferStatus.TDS_BUFSTAT_ATTNACK) || bufferStatus.HasFlag(BufferStatus.TDS_BUFSTAT_ATTN);
 
                     if (bufferStatus.HasFlag(BufferStatus.TDS_BUFSTAT_EOM))
                     {
@@ -82,13 +110,47 @@ namespace AdoNetCore.AseClient.Internal
 
                 if (canceled)
                 {
-                    return new IToken[0];
+                    Logger.Instance?.WriteLine($"{nameof(RegularSocket)} - received cancel status flag");
+                    return new IToken[]
+                    {
+                        new DoneToken
+                        {
+                            Count = 0,
+                            Status = DoneToken.DoneStatus.TDS_DONE_ATTN
+                        }
+                    };
                 }
 
                 ms.Seek(0, SeekOrigin.Begin);
 
                 LastActive = DateTime.UtcNow;
                 return _parser.Parse(ms, env.Encoding);
+            }
+        }
+
+        private void DumpBytes(byte[] bytes, int length)
+        {
+            if (bytes.Length == length)
+            {
+                DumpBytes(bytes);
+                return;
+            }
+
+            if (_hexDump)
+            {
+                var buffer = new byte[length];
+                Array.Copy(bytes, buffer, length);
+                Logger.Instance?.Write(Environment.NewLine);
+                Logger.Instance?.Write(HexDump.Dump(bytes));
+            }
+        }
+
+        private void DumpBytes(byte[] bytes)
+        {
+            if (_hexDump)
+            {
+                Logger.Instance?.Write(Environment.NewLine);
+                Logger.Instance?.Write(HexDump.Dump(bytes));
             }
         }
     }

--- a/src/AdoNetCore.AseClient/Internal/SqlDecimal.cs
+++ b/src/AdoNetCore.AseClient/Internal/SqlDecimal.cs
@@ -102,7 +102,7 @@ namespace AdoNetCore.AseClient.Internal
         private static readonly double s_DMAX_NUME = 1.0e+38;                  // Max value of numeric
         private static readonly uint s_DBL_DIG = 17;                       // Max decimal digits of double
 
-        private static readonly byte s_cNumeDivScaleMin = 6;     // Minimum result scale of numeric division
+        //private static readonly byte s_cNumeDivScaleMin = 6;     // Minimum result scale of numeric division
 
         // Array of multipliers for lAdjust and Ceiling/Floor.
         private static readonly uint[] s_rgulShiftBase = new uint[9] {

--- a/src/AdoNetCore.AseClient/Internal/StreamReadExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/StreamReadExtensions.cs
@@ -206,7 +206,6 @@ namespace AdoNetCore.AseClient.Internal
             };
             var remainingLength = length - 1;
             stream.Read(buffer, 16 - remainingLength, remainingLength);
-            //buffer = buffer.Reverse().ToArray();
 
             buffer = new[]
             {

--- a/src/AdoNetCore.AseClient/Packet/AttentionPacket.cs
+++ b/src/AdoNetCore.AseClient/Packet/AttentionPacket.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using AdoNetCore.AseClient.Enum;
+using AdoNetCore.AseClient.Interface;
+
+namespace AdoNetCore.AseClient.Packet
+{
+    internal class AttentionPacket : IPacket
+    {
+        public BufferType Type => BufferType.TDS_BUF_ATTN;
+        public BufferStatus Status => BufferStatus.TDS_BUFSTAT_ATTN | BufferStatus.TDS_BUFSTAT_EOM;
+
+        public void Write(Stream stream, Encoding enc) { }
+    }
+}

--- a/src/AdoNetCore.AseClient/Packet/AttentionPacket.cs
+++ b/src/AdoNetCore.AseClient/Packet/AttentionPacket.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;

--- a/src/AdoNetCore.AseClient/Packet/LoginPacket.cs
+++ b/src/AdoNetCore.AseClient/Packet/LoginPacket.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
@@ -59,6 +58,8 @@ namespace AdoNetCore.AseClient.Packet
         private int TDS_PKTLEN = 6;
 
         public BufferType Type => BufferType.TDS_BUF_LOGIN;
+        public BufferStatus Status => BufferStatus.TDS_BUFSTAT_NONE;
+
         public void Write(Stream stream, Encoding enc)
         {
             Logger.Instance?.WriteLine($"Write {Type}");

--- a/src/AdoNetCore.AseClient/Packet/NormalPacket.cs
+++ b/src/AdoNetCore.AseClient/Packet/NormalPacket.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using AdoNetCore.AseClient.Enum;
@@ -13,6 +12,7 @@ namespace AdoNetCore.AseClient.Packet
         private readonly IEnumerable<IToken> _tokens;
 
         public BufferType Type => BufferType.TDS_BUF_NORMAL;
+        public BufferStatus Status => BufferStatus.TDS_BUFSTAT_NONE;
 
         public NormalPacket(params IToken[] tokens)
         {

--- a/src/AdoNetCore.AseClient/Token/LoginAckToken.cs
+++ b/src/AdoNetCore.AseClient/Token/LoginAckToken.cs
@@ -45,20 +45,19 @@ namespace AdoNetCore.AseClient.Token
         public void Read(Stream stream, Encoding enc, IFormatToken previous)
         {
             var remainingLength = stream.ReadUShort();
-            byte[] versionBuffer;
             using (var ts = new ReadablePartialStream(stream, remainingLength))
             {
                 Status = (LoginStatus)ts.ReadByte();
-
-                versionBuffer = new byte[4];
+                var versionBuffer = new byte[4];
                 ts.Read(versionBuffer, 0, 4);
                 TdsVersion = $"{versionBuffer[0]}.{versionBuffer[1]}.{versionBuffer[2]}.{versionBuffer[3]}";
 
                 ProgramName = ts.ReadByteLengthPrefixedString(enc);
 
                 ts.Read(versionBuffer, 0, 4);
+                ProgramVersion = $"{versionBuffer[0]}.{versionBuffer[1]}.{versionBuffer[2]}"; //Sybase driver only reports the first 3 version numbers, eg: 15.0.0
             }
-            ProgramVersion = $"{versionBuffer[0]}.{versionBuffer[1]}.{versionBuffer[2]}.{versionBuffer[3]}";
+            Logger.Instance?.WriteLine($"<- {Type}: TDS {TdsVersion}, {ProgramName} {ProgramVersion}");
         }
 
         public static LoginAckToken Create(Stream stream, Encoding enc, IFormatToken previous)

--- a/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using AdoNetCore.AseClient.Internal;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -13,16 +15,20 @@ namespace AdoNetCore.AseClient.Tests.Integration
     {
         private readonly Dictionary<string, string> _connectionStrings = JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText("ConnectionStrings.json"));
 
-        [Test]
-        public void Async_NoCancel_Succeeds()
+        public CancelTests()
         {
-            Logger.Enable();
+            Logger.Enable(timestamps: true);
+        }
+
+        [Test]
+        public void ExecuteNonQueryAsync_NoCancel_Succeeds()
+        {
             using (var connection = new AseConnection(_connectionStrings["default"]))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText = "waitfor delay '00:00:02' select 1";
+                    command.CommandText = "waitfor delay '00:00:01'";
                     command.CommandType = CommandType.Text;
                     command.ExecuteNonQueryAsync(new CancellationToken()).Wait();
                 }
@@ -30,26 +36,56 @@ namespace AdoNetCore.AseClient.Tests.Integration
         }
 
         [Test]
-        public void Async_Cancel_Succeeds()
+        public void ExecuteNonQueryAsync_AlreadyCanceled_Cancels()
         {
-            Logger.Enable();
             using (var connection = new AseConnection(_connectionStrings["default"]))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText = "waitfor delay '00:00:10' select 1";
+                    command.CommandText = "waitfor delay '00:00:10'";
                     command.CommandType = CommandType.Text;
-                    var cts = new CancellationTokenSource();
-                    var token = cts.Token;
-
-                    Assert.IsTrue(token.CanBeCanceled);
-                    token.Register(() => Logger.Instance.WriteLine($"CANCELATION"));
-                    
-                    var task = command.ExecuteNonQueryAsync(token);
-                    cts.Cancel();
-                    task.Wait();
+                    var task = command.ExecuteNonQueryAsync(new CancellationToken(true));
+                    var ex = Assert.Throws<AggregateException>(() => task.Wait());
+                    Assert.IsTrue(ex.InnerException is TaskCanceledException);
                     Assert.IsTrue(task.IsCanceled);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteNonQueryAsync_DelayedCancel_Cancels()
+        {
+            using (var connection = new AseConnection(_connectionStrings["default"]))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "waitfor delay '00:00:10'";
+                    command.CommandType = CommandType.Text;
+                    var cts = new CancellationTokenSource(100);
+                    var task = command.ExecuteNonQueryAsync(cts.Token);
+                    var ex = Assert.Throws<AggregateException>(() => task.Wait());
+                    Assert.IsTrue(ex.InnerException is TaskCanceledException);
+                    Assert.IsTrue(task.IsCanceled);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteQuickNonQueryAsync_DelayedCancel_DoesNothing()
+        {
+            using (var connection = new AseConnection(_connectionStrings["default"]))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "select 1";
+                    command.CommandType = CommandType.Text;
+                    var cts = new CancellationTokenSource(100);
+                    var task = command.ExecuteNonQueryAsync(cts.Token);
+                    task.Wait();
+                    Assert.IsTrue(task.IsCompleted);
                 }
             }
         }

--- a/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Dapper;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration
+{
+    [TestFixture]
+    public class CancelTests
+    {
+        private readonly Dictionary<string, string> _connectionStrings = JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText("ConnectionStrings.json"));
+
+        [Test]
+        public void Blah()
+        {
+            using (var connection = new AseConnection(_connectionStrings["default"]))
+            {
+                var source = new CancellationTokenSource();
+                var task = connection.QueryAsync<int>(new CommandDefinition("select 1", cancellationToken: source.Token));
+                source.Cancel();
+                task.Wait();
+            }
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using AdoNetCore.AseClient.Internal;
 using Dapper;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -32,6 +33,11 @@ begin
 end";
 
         private readonly string _dropProc = @"drop procedure [dbo].[sp_test_echo]";
+
+        public EchoProcedureTests()
+        {
+            Logger.Disable();
+        }
 
         [SetUp]
         public void Setup()

--- a/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
@@ -18,6 +18,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [TestCase("big-packetsize")]
         public void Login_Success(string csName)
         {
+            Logger.Enable();
             using (var connection = new AseConnection(_connectionStrings[csName]))
             {
                 connection.Open();

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -72,6 +72,23 @@ namespace AdoNetCore.AseClient.Tests.Unit
             Assert.IsNull(connection.Database);
         }
 
+        [Test]
+        public void ConstructConnection_WithoutOpening_DataSourceIsNull()
+        {
+            var connectionString = "Data Source=myASEserver;Port=5000;Database=myDataBase;Uid=myUsername;Pwd=myPassword;";
+            var connection = new AseConnection(connectionString);
+
+            Assert.IsNull(connection.DataSource);
+        }
+
+        [Test]
+        public void ConstructConnection_WithoutOpening_ServerVersionIsNull()
+        {
+            var connectionString = "Data Source=myASEserver;Port=5000;Database=myDataBase;Uid=myUsername;Pwd=myPassword;";
+            var connection = new AseConnection(connectionString);
+
+            Assert.IsNull(connection.ServerVersion);
+        }
 
         [Test]
         public void OpenConnection_WithInvalidConnectionString_ThrowsArgumentException()

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -194,7 +194,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
 
             // Assert
             Assert.IsNotNull(command);
-            Assert.AreEqual(namedParameters, command.NamedParameters);
+            Assert.AreEqual(namedParameters, ((AseCommand)command).NamedParameters);
         }
 
         [Test]


### PR DESCRIPTION
Moved `Ase`-prefixed types over to extend the `Db`-prefixed types in `System.Data.Common`, rather than the interfaces.

Implemented `Cancel` function, and some `InternalConnection` state transitions (including a `Broken` state, that can be reached if the connection does something unusual)

Overrode and implemented `ExecuteNonQueryAsync`, `ExecuteDbDataReaderAsync`, and `ExecuteScalarAsync` in `AseCommand`