### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
@@ -9,11 +9,23 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/DataAction/AdoNetCore.AseClient/master/LICENSE</PackageLicenseUrl>
     <PackageReleaseNotes>Return column aliases if available</PackageReleaseNotes>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netcoreapp1.1'">
-    <DefineConstants>$(DefineConstants);NETCORE_OLD</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+    <DefineConstants>$(DefineConstants);NET_FRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46'">
     <DefineConstants>$(DefineConstants);ENABLE_DB_DATAPERMISSION</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);ENABLE_CLONEABLE_INTERFACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);ENABLE_SYSTEMEXCEPTION</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netcoreapp1.1'">
+    <DefineConstants>$(DefineConstants);LONG_ARRAY_COPY_UNAVAILABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />

--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net46;netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.9.2</VersionPrefix>
     <Authors>dataaction</Authors>
     <Description>.NET Core data provider for Sybase ASE</Description>
@@ -12,13 +12,13 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netcoreapp1.1'">
     <DefineConstants>$(DefineConstants);NETCORE_OLD</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46'">
+    <DefineConstants>$(DefineConstants);ENABLE_DB_DATAPERMISSION</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">

--- a/src/AdoNetCore.AseClient/AseClientPermission.cs
+++ b/src/AdoNetCore.AseClient/AseClientPermission.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_DB_DATAPERMISSION
 using System;
 using System.Data;
 using System.Data.Common;

--- a/src/AdoNetCore.AseClient/AseClientPermissionAttribute.cs
+++ b/src/AdoNetCore.AseClient/AseClientPermissionAttribute.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_DB_DATAPERMISSION
 using System;
 using System.Data.Common;
 using System.Security;

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -11,7 +11,7 @@ namespace AdoNetCore.AseClient
     /// Represents a Transact-SQL statement or stored procedure to execute against a SAP ASE database. This class cannot be inherited.
     /// </summary>
     public sealed class AseCommand : DbCommand
-#if NETCOREAPP2_0 || NET45 || NET46
+#if ENABLE_CLONEABLE_INTERFACE
         , ICloneable
 #endif
     {
@@ -479,7 +479,7 @@ namespace AdoNetCore.AseClient
                 }).Unwrap();
         }
 
-#if NETCOREAPP2_0 || NET45 || NET46
+#if ENABLE_CLONEABLE_INTERFACE
         object ICloneable.Clone()
         {
             var clone = new AseCommand(Connection)

--- a/src/AdoNetCore.AseClient/AseCommandBuilder.cs
+++ b/src/AdoNetCore.AseClient/AseCommandBuilder.cs
@@ -1,10 +1,9 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
-using AdoNetCore.AseClient.Enum;
 
 namespace AdoNetCore.AseClient
 {

--- a/src/AdoNetCore.AseClient/AseDataAdapter.cs
+++ b/src/AdoNetCore.AseClient/AseDataAdapter.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/AdoNetCore.AseClient/AseDataReader.cs
+++ b/src/AdoNetCore.AseClient/AseDataReader.cs
@@ -19,7 +19,7 @@ namespace AdoNetCore.AseClient
         private readonly AseCommand _command;
         private readonly CommandBehavior _behavior;
 
-#if !NETCORE_OLD
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         private DataTable _currentSchemaTable;
 #endif
 
@@ -116,7 +116,7 @@ namespace AdoNetCore.AseClient
                 bytesToRead = byteArrayLength - fieldOffset; // Shrink the bytes requested.
             }
 
-#if NETCOREAPP1_0 || NETCOREAPP1_1
+#if LONG_ARRAY_COPY_UNAVAILABLE
             var cIndex = fieldOffset;
             var bIndex = (long)bufferOffset;
 
@@ -561,18 +561,13 @@ namespace AdoNetCore.AseClient
 
         public override object this[string name] => GetValue(GetOrdinal(name));
 
-#if NETCORE_OLD
-        public void Close() { }
-#else
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         public override void Close() { }
+#else
+        public void Close() { }
 #endif
 
-#if NETCORE_OLD
-        public DataTable GetSchemaTable()
-        {
-            return null;
-        }
-#else
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         public override DataTable GetSchemaTable()
         {
             EnsureSchemaTable();
@@ -747,6 +742,11 @@ namespace AdoNetCore.AseClient
 
             _currentSchemaTable = table;
         }
+#else
+        public DataTable GetSchemaTable()
+        {
+            return null;
+        }
 #endif
 
         /// <summary>
@@ -771,7 +771,7 @@ namespace AdoNetCore.AseClient
 
             _currentResult++;
 
-#if !NETCORE_OLD
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
             _currentSchemaTable = null;
 #endif
 

--- a/src/AdoNetCore.AseClient/AseException.cs
+++ b/src/AdoNetCore.AseClient/AseException.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#if !NETCORE_OLD
+#if ENABLE_SYSTEMEXCEPTION
 using System.Runtime.Serialization;
 #endif
 
@@ -8,14 +8,14 @@ namespace AdoNetCore.AseClient
     /// <summary>
     /// The exception that is thrown when ASE returns a warning or error. This class cannot be inherited.
     /// </summary>
-#if !NETCORE_OLD
+#if ENABLE_SYSTEMEXCEPTION
     [Serializable]
 #endif
     public sealed class AseException :
-#if NETCORE_OLD
-    Exception
-#else
+#if ENABLE_SYSTEMEXCEPTION
     SystemException
+#else
+    Exception
 #endif
     {
         /// <summary>
@@ -107,7 +107,7 @@ namespace AdoNetCore.AseClient
             Errors = new AseErrorCollection(errors);
         }
 
-#if !NETCORE_OLD
+#if ENABLE_SYSTEMEXCEPTION
         private AseException(SerializationInfo info, StreamingContext context) : base(info, context) {
             Errors = new AseErrorCollection(new AseError
             {

--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -9,7 +9,7 @@ namespace AdoNetCore.AseClient
     /// Represents a parameter to an <see cref="AseCommand" />. This class cannot be inherited.
     /// </summary>
     public sealed class AseParameter : DbParameter
-#if NETCOREAPP2_0 || NET45 || NET46
+#if ENABLE_CLONEABLE_INTERFACE
         , ICloneable
 #endif
     {
@@ -302,7 +302,7 @@ namespace AdoNetCore.AseClient
         /// <summary>
         /// Gets or sets the <see cref="AseDbType" /> of the parameter.
         /// </summary>
-#if !NETCORE_OLD
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         [DbProviderSpecificTypeProperty(true)]
 #endif
         public AseDbType AseDbType
@@ -372,10 +372,10 @@ namespace AdoNetCore.AseClient
 
         public override bool SourceColumnNullMapping { get; set; }
 
-#if NETCORE_OLD
-        public DataRowVersion SourceVersion { get; set; }
-#else
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         public override DataRowVersion SourceVersion { get; set; }
+#else
+        public DataRowVersion SourceVersion { get; set; }
 #endif
         /// <summary>
         /// Gets or sets the value of the parameter.
@@ -407,11 +407,7 @@ namespace AdoNetCore.AseClient
         /// passing it to the database, use the <see cref="System.Math" /> class that is part of the System namespace prior to assigning a value to 
         /// the parameter's <see cref="Value" /> property.</para>
         /// </remarks>
-#if NET45
-        public byte Precision { get; set; }
-#else
         public override byte Precision { get; set; }
-#endif
 
         /// <summary>
         /// Gets or sets the number of decimal places to which <see cref="Value" /> is resolved.
@@ -428,11 +424,7 @@ namespace AdoNetCore.AseClient
         /// passing it to the database, use the <see cref="System.Math" /> class that is part of the System namespace prior to assigning a value to 
         /// the parameter's <see cref="Value" /> property.</para>
         /// </remarks>
-#if NET45
-        public byte Scale { get; set; }
-#else
         public override byte Scale { get; set; }
-#endif
 
         /// <summary>
         /// Gets or sets the maximum size, in bytes, of the data within the column.
@@ -466,8 +458,7 @@ namespace AdoNetCore.AseClient
             return ParameterName ?? ParameterIndex.ToString();
         }
 
-
-#if NETCOREAPP2_0 || NET45 || NET46
+#if ENABLE_CLONEABLE_INTERFACE
         object ICloneable.Clone()
         {
             var clone = new AseParameter

--- a/src/AdoNetCore.AseClient/AseParameterCollection.cs
+++ b/src/AdoNetCore.AseClient/AseParameterCollection.cs
@@ -49,16 +49,16 @@ namespace AdoNetCore.AseClient
             }
         }
 
-#if NETCORE_OLD
-        public bool IsFixedSize => ((IList)_parameters).IsFixedSize;
-#else
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         public override bool IsFixedSize => ((IList)_parameters).IsFixedSize;
+#else
+        public bool IsFixedSize => ((IList)_parameters).IsFixedSize;
 #endif
 
-#if NETCORE_OLD
-        public bool IsReadOnly => ((IList)_parameters).IsReadOnly;
-#else
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         public override bool IsReadOnly => ((IList)_parameters).IsReadOnly;
+#else
+        public bool IsReadOnly => ((IList)_parameters).IsReadOnly;
 #endif
 
         /// <summary>
@@ -66,10 +66,10 @@ namespace AdoNetCore.AseClient
         /// </summary>
         public override int Count => _parameters.Count;
 
-#if NETCORE_OLD
-        public bool IsSynchronized => ((IList)_parameters).IsSynchronized;
-#else
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
         public override bool IsSynchronized => ((IList)_parameters).IsSynchronized;
+#else
+        public bool IsSynchronized => ((IList)_parameters).IsSynchronized;
 #endif
 
         public override object SyncRoot => ((IList)_parameters).SyncRoot;

--- a/src/AdoNetCore.AseClient/AseRowUpdatedEventArgs.cs
+++ b/src/AdoNetCore.AseClient/AseRowUpdatedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 using System.Data;
 using System.Data.Common;
 

--- a/src/AdoNetCore.AseClient/AseRowUpdatedEventHandler.cs
+++ b/src/AdoNetCore.AseClient/AseRowUpdatedEventHandler.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 namespace AdoNetCore.AseClient
 {
     public delegate void AseRowUpdatedEventHandler(object sender, AseRowUpdatedEventArgs e);

--- a/src/AdoNetCore.AseClient/AseRowUpdatingEventArgs.cs
+++ b/src/AdoNetCore.AseClient/AseRowUpdatingEventArgs.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 using System.Data;
 using System.Data.Common;
 

--- a/src/AdoNetCore.AseClient/AseRowUpdatingEventHandler.cs
+++ b/src/AdoNetCore.AseClient/AseRowUpdatingEventHandler.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 namespace AdoNetCore.AseClient
 {
     /// <summary>

--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -33,7 +33,7 @@ namespace AdoNetCore.AseClient.Internal
 
                 socket = new Socket(_endpoint.AddressFamily, SocketType.Stream, ProtocolType.IP);
 
-#if NET45 || NET46
+#if NET_FRAMEWORK
                 var connect = Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, _endpoint, null);
 #else
                 var connect = socket.ConnectAsync(_endpoint);

--- a/test/AdoNetCore.AseClient.Benchmark/AdoNetCore.AseClient.Benchmark.csproj
+++ b/test/AdoNetCore.AseClient.Benchmark/AdoNetCore.AseClient.Benchmark.csproj
@@ -8,6 +8,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp1.1|AnyCPU'">
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+    <DefineConstants>$(DefineConstants);NET_FRAMEWORK</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp1.0'">
+    <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.11" />
     <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.11" />

--- a/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
+++ b/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
@@ -29,14 +29,14 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  </ItemGroup>-->
+  <!--<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="System.Security.Permissions">
       <Version>4.4.1</Version>
     </PackageReference>
-  </ItemGroup>
+  </ItemGroup>-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="Sybase.AdoNet4.AseClient">
       <Version>1.0.0</Version>

--- a/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
+++ b/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
@@ -19,9 +19,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' Or '$(TargetFramework)' == 'netcoreapp1.1'">
-    <DefineConstants>$(DefineConstants);NETCORE_OLD</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
+    <DefineConstants>$(DefineConstants);NET_FRAMEWORK</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp1.0'">
+    <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
@@ -29,14 +34,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
   </ItemGroup>
-  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-  </ItemGroup>-->
-  <!--<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.Security.Permissions">
-      <Version>4.4.1</Version>
-    </PackageReference>
-  </ItemGroup>-->
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="Sybase.AdoNet4.AseClient">
       <Version>1.0.0</Version>

--- a/test/AdoNetCore.AseClient.Tests/Benchmark/BenchmarkTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Benchmark/BenchmarkTests.cs
@@ -9,6 +9,7 @@ namespace AdoNetCore.AseClient.Tests.Benchmark
 #if NETCORE_OLD || NETCOREAPP2_0 || NET46
     [TestFixture(typeof(CoreFxConnectionProvider))]
 #endif
+    [Category("benchmark")]
     public partial class Benchmarks<T> where T : IConnectionProvider
     {
 

--- a/test/AdoNetCore.AseClient.Tests/Benchmark/BenchmarkTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Benchmark/BenchmarkTests.cs
@@ -3,10 +3,10 @@ using NUnit.Framework;
 
 namespace AdoNetCore.AseClient.Tests.Benchmark
 {
-#if NET46
+#if NET_FRAMEWORK
     [TestFixture(typeof(SapConnectionProvider))]
 #endif
-#if NETCORE_OLD || NETCOREAPP2_0 || NET46
+#if NET_CORE || NET_FRAMEWORK
     [TestFixture(typeof(CoreFxConnectionProvider))]
 #endif
     [Category("benchmark")]

--- a/test/AdoNetCore.AseClient.Tests/Benchmark/CoreFxConnectionProvider.cs
+++ b/test/AdoNetCore.AseClient.Tests/Benchmark/CoreFxConnectionProvider.cs
@@ -6,10 +6,10 @@ namespace AdoNetCore.AseClient.Tests.Benchmark
     {
         public DbConnection GetConnection(string connectionString)
         {
-#if NETCORE_OLD || NETCOREAPP2_0 || NET46
+#if NETCORE_OLD || NETCOREAPP2_0 || NET46 || NETSTANDARD2_0
             return new AseConnection(connectionString);
 #else
-            throw new NotSupportedException("The AdoNetCore AseClient only supports .NET 4+ and .NET Core");
+            throw new NotSupportedException("The AdoNetCore AseClient only supports .NET 4+, .NET Core, and .NET Standard 2.0");
 #endif
         }
     }

--- a/test/AdoNetCore.AseClient.Tests/Benchmark/CoreFxConnectionProvider.cs
+++ b/test/AdoNetCore.AseClient.Tests/Benchmark/CoreFxConnectionProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.Common;
+﻿using System;
+using System.Data.Common;
 
 namespace AdoNetCore.AseClient.Tests.Benchmark
 {
@@ -6,10 +7,10 @@ namespace AdoNetCore.AseClient.Tests.Benchmark
     {
         public DbConnection GetConnection(string connectionString)
         {
-#if NETCORE_OLD || NETCOREAPP2_0 || NET46 || NETSTANDARD2_0
+#if NET_CORE || NET_FRAMEWORK
             return new AseConnection(connectionString);
 #else
-            throw new NotSupportedException("The AdoNetCore AseClient only supports .NET 4+, .NET Core, and .NET Standard 2.0");
+            throw new NotSupportedException("The AdoNetCore AseClient only supports .NET 4+ and .NET Core");
 #endif
         }
     }

--- a/test/AdoNetCore.AseClient.Tests/Benchmark/SapConnectionProvider.cs
+++ b/test/AdoNetCore.AseClient.Tests/Benchmark/SapConnectionProvider.cs
@@ -7,7 +7,7 @@ namespace AdoNetCore.AseClient.Tests.Benchmark
     {
         public DbConnection GetConnection(string connectionString)
         {
-#if NET46
+#if NET_FRAMEWORK
             return new Sybase.Data.AseClient.AseConnection(connectionString);
 #else
             throw new NotSupportedException("The SAP AseClient only supports .NET 4+");

--- a/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
+++ b/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
@@ -37,7 +37,7 @@ namespace AdoNetCore.AseClient.Tests
 
             try
             {
-#if NET46
+#if NET_FRAMEWORK
                 fileText = File.ReadAllText(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseLoginDetails.json"));
 #else
                 fileText = File.ReadAllText("DatabaseLoginDetails.json");

--- a/test/AdoNetCore.AseClient.Tests/Integration/AliasTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AliasTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("quick")]
     public class AliasTests
     {
         private IDbConnection GetConnection()

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseConnectionPoolManagerTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseConnectionPoolManagerTests.cs
@@ -3,6 +3,7 @@
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("extra")]
     public class AseConnectionPoolManagerTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseDataAdapterTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseDataAdapterTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("extra")]
     public class AseDataAdapterTests
     {
         [SetUp]

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseDataAdapterTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseDataAdapterTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCORE_OLD
+﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 using System.Collections.Generic;
 using System.Data;
 using System.Text.RegularExpressions;

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseDataReaderTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseDataReaderTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("extra")]
     public class AseDataReaderTests
     {
         private const string AllTypesQuery =

--- a/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class CancelTests
     {
         public CancelTests()

--- a/test/AdoNetCore.AseClient.Tests/Integration/ChangeDatabaseTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/ChangeDatabaseTests.cs
@@ -3,6 +3,7 @@
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class ChangeDatabaseTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Integration/DataSetTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/DataSetTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("extra")]
     public class DataSetTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
@@ -14,6 +14,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
     /// For benchmarking, copy this to a new project referencing the AdoNet4.AseClient dll. Hopefully we don't perform too poorly by comparison :)
     /// </summary>
     [TestFixture]
+    [Category("basic")]
     public class EchoProcedureTests
     {
         private readonly string _createProc = @"

--- a/test/AdoNetCore.AseClient.Tests/Integration/InternalConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/InternalConnectionTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class InternalConnectionTests
     {
         public InternalConnectionTests()

--- a/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class LoginTests
     {
         [TestCaseSource(nameof(Login_Success_Cases))]

--- a/test/AdoNetCore.AseClient.Tests/Integration/MultiTypeEchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/MultiTypeEchoProcedureTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class MultiTypeEchoProcedureTests
     {
         private readonly string _createProc = @"

--- a/test/AdoNetCore.AseClient.Tests/Integration/RaiserrorProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/RaiserrorProcedureTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class RaiserrorProcedureTests
     {
         private readonly string _createProc = @"

--- a/test/AdoNetCore.AseClient.Tests/Integration/SimpleProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/SimpleProcedureTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class SimpleProcedureTests
     {
         private readonly string _createProc = @"create procedure [dbo].[sp_test_simple] as begin return end";

--- a/test/AdoNetCore.AseClient.Tests/Integration/SimpleQueryTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/SimpleQueryTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class SimpleQueryTests
     {
         public SimpleQueryTests()

--- a/test/AdoNetCore.AseClient.Tests/Integration/StringTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/StringTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class StringTests
     {
         private IDbConnection GetConnection()

--- a/test/AdoNetCore.AseClient.Tests/Integration/TransactionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TransactionTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Integration
 {
     [TestFixture]
+    [Category("basic")]
     public class TransactionTests
     {
         private IDbConnection GetConnection()

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class AseConnectionTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseDecimalTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseDecimalTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class AseDecimalTests
     {
         public AseDecimalTests()

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseParameterCollectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseParameterCollectionTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class AseParameterCollectionTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseParameterTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseParameterTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class AseParameterTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class AseTransactionTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Unit/ConnectionParametersTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/ConnectionParametersTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class ConnectionParametersTests
     {
         [Test]

--- a/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class ConnectionPoolTests
     {
         public ConnectionPoolTests()

--- a/test/AdoNetCore.AseClient.Tests/Unit/ConnectionStringTokeniserTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/ConnectionStringTokeniserTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class ConnectionStringTokeniserTests
     {
         [TestCase("Data Source=myASEserver;Port=5000;Database=myDataBase;Uid=myUsername;Pwd=myPassword;", 5)]

--- a/test/AdoNetCore.AseClient.Tests/Unit/LoginPacketTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/LoginPacketTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class LoginPacketTests
     {
         /*

--- a/test/AdoNetCore.AseClient.Tests/Unit/MessageTokenHandlerTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/MessageTokenHandlerTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 namespace AdoNetCore.AseClient.Tests.Unit
 {
     [TestFixture]
+    [Category("quick")]
     public class MessageTokenHandlerTests
     {
         [Test]


### PR DESCRIPTION
Fix for issue #23 
The first commit adds `netstandard2.0` to `TargetFrameworks` and gets it building
Subsequent commits relate to switching to nicer compile flags, and more usable CLI test-running.