### PR TITLE
Default size for variable-length output parameters

### DIFF
--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -447,9 +447,16 @@ namespace AdoNetCore.AseClient
         /// </remarks>
         public override int Size { get; set; }
 
+        /// <summary>
+        /// Indicates if this parameter can be sent to the server (normal:true),
+        /// or if it's an abstraction over return values (ParameterDirection.ReturnValue:false)
+        /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal bool CanSendOverTheWire => Direction != ParameterDirection.ReturnValue;
 
+        /// <summary>
+        /// Indicates if this parameter will have an output value
+        /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         internal bool IsOutput => Direction == ParameterDirection.InputOutput || Direction == ParameterDirection.Output;
 

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -62,16 +62,16 @@ namespace AdoNetCore.AseClient.Internal
 
         public static int? GetFormatLength(DbType dbType, AseParameter parameter, Encoding enc)
         {
-            if (parameter.Size > 0)
-            {
-                return parameter.Size;
-            }
-
             var value = parameter.SendableValue;
             switch (dbType)
             {
                 case DbType.String:
                 case DbType.StringFixedLength:
+                    if (parameter.IsOutput)
+                    {
+                        return Math.Max(VarLongBoundary * 2, parameter.Size);
+                    }
+
                     switch (value)
                     {
                         case string s:
@@ -83,6 +83,11 @@ namespace AdoNetCore.AseClient.Internal
                     }
                 case DbType.AnsiString:
                 case DbType.AnsiStringFixedLength:
+                    if (parameter.IsOutput)
+                    {
+                        return Math.Max(VarLongBoundary, parameter.Size);
+                    }
+
                     switch (value)
                     {
                         case string s:
@@ -93,6 +98,11 @@ namespace AdoNetCore.AseClient.Internal
                             return 0;
                     }
                 case DbType.Binary:
+                    if (parameter.IsOutput)
+                    {
+                        return Math.Max(VarLongBoundary, parameter.Size);
+                    }
+
                     switch (value)
                     {
                         case byte[] ba:

--- a/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
@@ -10,13 +10,11 @@ using NUnit.Framework;
 
 namespace AdoNetCore.AseClient.Tests.Integration
 {
-    /// <summary>
-    /// For benchmarking, copy this to a new project referencing the AdoNet4.AseClient dll. Hopefully we don't perform too poorly by comparison :)
-    /// </summary>
     [TestFixture]
     [Category("basic")]
     public class EchoProcedureTests
     {
+        //echo an int
         private readonly string _createProc = @"
 create procedure [dbo].[sp_test_echo]
   @nEchoValue int,
@@ -30,7 +28,8 @@ begin
 end";
 
         private readonly string _dropProc = @"drop procedure [dbo].[sp_test_echo]";
-
+        
+        //echo a character
         private readonly string _createEchoCharProc = @"create procedure [dbo].[sp_test_echo_char]
   @input char(1),
   @output char(1) output
@@ -41,6 +40,7 @@ end";
 
         private readonly string _dropEchoCharProc = @"drop procedure [dbo].[sp_test_echo_char]";
 
+        //echo a string
         private readonly string _createEchoStringProc = @"create procedure [dbo].[sp_test_echo_string]
   @input char(255),
   @output char(255) output
@@ -50,6 +50,17 @@ begin
 end";
 
         private readonly string _dropEchoStringProc = @"drop procedure [dbo].[sp_test_echo_string]";
+
+        //echo some bytes
+        private readonly string _createEchoBinaryProc = @"create procedure [dbo].[sp_test_echo_binary]
+  @input binary(255),
+  @output binary(255) output
+as
+begin
+  set @output = @input
+end";
+
+        private readonly string _dropEchoBinaryProc = @"drop procedure [dbo].[sp_test_echo_binary]";
 
         public EchoProcedureTests()
         {
@@ -64,6 +75,7 @@ end";
                 connection.Execute(_createProc);
                 connection.Execute(_createEchoCharProc);
                 connection.Execute(_createEchoStringProc);
+                connection.Execute(_createEchoBinaryProc);
             }
         }
 
@@ -155,15 +167,18 @@ end";
             }
         }
 
-        [Test]
-        public void EchoString_Procedure_ShouldExecute()
+        [TestCase(DbType.AnsiStringFixedLength)] //CHAR:0(255)
+        [TestCase(DbType.AnsiString)] //VARCHAR:0(255)
+        [TestCase(DbType.StringFixedLength)] //LONGBINARY:34(510)
+        [TestCase(DbType.String)] //LONGBINARY:35(510)
+        public void EchoString_Procedure_ShouldExecute(DbType outputType)
         {
             using (var connection = new AseConnection(ConnectionStrings.Default))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText = "sp_test_echo_char";
+                    command.CommandText = "sp_test_echo_string";
                     command.CommandType = CommandType.StoredProcedure;
 
                     var expected = new string('.', 255);
@@ -177,7 +192,40 @@ end";
                     var pOut = command.CreateParameter();
                     pOut.ParameterName = "@output";
                     pOut.Value = DBNull.Value;
-                    pOut.DbType = DbType.AnsiStringFixedLength;
+                    pOut.DbType = outputType;
+                    pOut.Direction = ParameterDirection.Output;
+                    command.Parameters.Add(pOut);
+
+                    command.ExecuteNonQuery();
+
+                    Assert.AreEqual(expected, pOut.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void EchoBinary_Procedure_ShouldExecute()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "sp_test_echo_binary";
+                    command.CommandType = CommandType.StoredProcedure;
+
+                    var expected = Enumerable.Repeat(new byte[] {0xde, 0xad, 0xbe, 0xef}, 64).SelectMany(x => x).Take(255).ToArray();
+
+                    var p = command.CreateParameter();
+                    p.ParameterName = "@input";
+                    p.Value = expected;
+                    p.DbType = DbType.Binary;
+                    command.Parameters.Add(p);
+
+                    var pOut = command.CreateParameter();
+                    pOut.ParameterName = "@output";
+                    pOut.Value = DBNull.Value;
+                    pOut.DbType = DbType.Binary;
                     pOut.Direction = ParameterDirection.Output;
                     command.Parameters.Add(pOut);
 
@@ -196,6 +244,7 @@ end";
                 connection.Execute(_dropProc);
                 connection.Execute(_dropEchoCharProc);
                 connection.Execute(_dropEchoStringProc);
+                connection.Execute(_dropEchoBinaryProc);
             }
         }
     }


### PR DESCRIPTION
Fixes issue #33.

For variable-length output parameters, the reference driver doesn't require client code to specify a `Size`, and uses a standard value instead (`255` or `510` depending on the type).
This PR is to replicate this behaviour, since it's useful for drop-in-replacements where existing client code does not specify a `Size`