### PR TITLE
Fix decimal parameter inference

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -41,6 +41,9 @@ namespace AdoNetCore.AseClient.Internal
             ? ColumnName
             : ColumnLabel;
 
+        public bool IsDecimalType => DataType == TdsDataType.TDS_DECN ||
+                                     DataType == TdsDataType.TDS_NUMN;
+
         /// <summary>
         /// Relates to TDS_BLOB
         /// </summary>
@@ -54,21 +57,18 @@ namespace AdoNetCore.AseClient.Internal
             //we need to know the DB
             var dbType = parameter.DbType;
             var length = TypeMap.GetFormatLength(dbType, parameter, env.Encoding);
-            var tdsDataType = TypeMap.GetTdsDataType(dbType, parameter.DbTypeIsKnown, parameter.SendableValue, length, parameter.ParameterName);
-            var tdsUserType = TypeMap.GetTdsUserType(dbType);
-            
             var format = new FormatItem
             {
                 ParameterName = parameter.ParameterName,
                 IsOutput = parameter.IsOutput,
                 IsNullable = parameter.IsNullable,
                 Length = length,
-                DataType = tdsDataType,
-                UserType = tdsUserType
+                DataType = TypeMap.GetTdsDataType(dbType, parameter.DbTypeIsKnown, parameter.SendableValue, length, parameter.ParameterName),
+                UserType = TypeMap.GetTdsUserType(dbType),
             };
 
             //fixup for decimal type
-            if (tdsDataType == TdsDataType.TDS_NUMN || tdsDataType == TdsDataType.TDS_DECN)
+            if (format.IsDecimalType)
             {
                 if (parameter.SendableValue == DBNull.Value)
                 {

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -51,10 +51,6 @@ namespace AdoNetCore.AseClient.Internal
 
         public static FormatItem CreateForParameter(AseParameter parameter, DbEnvironment env)
         {
-            //TDS_TYPE depends on (string/binary) Length
-            //(decimal) Length depends on TDS_TYPE
-            //we need to know the length of the value (if it's a string/binary) because the length determines the TDS type
-            //we need to know the DB
             var dbType = parameter.DbType;
             var length = TypeMap.GetFormatLength(dbType, parameter, env.Encoding);
             var format = new FormatItem
@@ -67,7 +63,7 @@ namespace AdoNetCore.AseClient.Internal
                 UserType = TypeMap.GetTdsUserType(dbType),
             };
 
-            //fixup for decimal type
+            //fixup the FormatItem's length,scale,precision for decimals
             if (format.IsDecimalType)
             {
                 if (parameter.SendableValue == DBNull.Value)

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -154,6 +154,19 @@ namespace AdoNetCore.AseClient.Internal
             throw new NotSupportedException($"Unsupported data type {dbType} for parameter '{parameterName}'.");
         }
 
+        public static int GetTdsUserType(DbType dbType)
+        {
+            switch (dbType)
+            {
+                case DbType.String:
+                    return 35;
+                case DbType.StringFixedLength:
+                    return 34;
+                default:
+                    return 0;
+            }
+        }
+
         private static readonly Dictionary<TdsDataType, Func<FormatItem, Type>> TdsToNetMap = new Dictionary<TdsDataType, Func<FormatItem, Type>>
         {
             {TdsDataType.TDS_BINARY, f => typeof(byte[])},

--- a/test/AdoNetCore.AseClient.Tests/Integration/SimpleQueryTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/SimpleQueryTests.cs
@@ -483,11 +483,31 @@ l:10, p:20, s:3: 01 00 00 00 00 00 00 00 03 e8
         }
 
         [TestCaseSource(nameof(SelectDecimal_Parameter_ShouldWork_Cases))]
-        public void SelectDecimal_Parameter_ShouldWork(decimal expected)
+        public void SelectDecimal_Parameter_Dapper_ShouldWork(decimal expected)
         {
             using (var connection = GetConnection())
             {
                 Assert.AreEqual(expected, connection.ExecuteScalar<decimal?>("select @expected", new { expected }));
+            }
+        }
+
+        [TestCaseSource(nameof(SelectDecimal_Parameter_ShouldWork_Cases))]
+        public void SelectDecimal_Parameter_Default_ShouldWork(decimal expected)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "select @expected";
+
+                    var p = command.CreateParameter();
+                    p.ParameterName = "@expected";
+                    p.Value = expected;
+                    command.Parameters.Add(p);
+
+                    Assert.AreEqual(expected, command.ExecuteScalar());
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #34 

I've duplicated one of the simple query tests for decimal parameters and un-dapper-ified it so that we can test what happens when building the parameter collection manually (labeled "default").

It might be good to open another issue/task to proactively expand more of the `SimpleQueryTests` into "dapper" and "default" forms.