### PR TITLE
Improve broken connection state handling

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
@@ -265,6 +265,7 @@ namespace AdoNetCore.AseClient.Internal
             if (ShouldRemoveAndReplace(connection, now))
             {
                 RemoveAndReplace(connection);
+                Logger.Instance?.WriteLine("Released connection was removed. Creation of a replacement was tasked.");
                 return;
             }
             

--- a/test/AdoNetCore.AseClient.Tests/Integration/Connection/BrokenStateTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Connection/BrokenStateTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Data;
+using AdoNetCore.AseClient.Internal;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration.Connection
+{
+    [TestFixture]
+    [Category("basic")]
+    public class BrokenStateTests
+    {
+        private AseConnection GetConnection()
+        {
+            Logger.Enable();
+            return new AseConnection(ConnectionStrings.Pooled);
+        }
+
+        [Test]
+        public void PooledConnection_WithBrokenState_IsNotReused()
+        {
+            //cause the broken state by triggering an InvalidCastException
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "select @p";
+                    var p = command.CreateParameter();
+                    p.DbType = DbType.Int16;
+                    p.Value = Guid.NewGuid();
+                    p.ParameterName = "@p";
+                    command.Parameters.Add(p);
+
+                    //We want to have the InvalidCastException thrown, so if the type coercion logic changes later this test can be updated
+                    Assert.Throws<InvalidCastException>(() => command.ExecuteReader());
+                }
+                Assert.IsTrue(connection.InternalConnection.IsDoomed);
+            }
+
+            //confirm that we can open a [fresh] connection
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #50 
Problem was that `InternalConnection` wasn't marking itself as doomed if it failed to `SendPackets`.
This would have a flow-on effect when the connection is released back into the pool, the pool would not notice the need to drop the connection outright.

Fix is to detect `SendPackets` failing, mark the connection as doomed, and let the pool handle it as normal.