### PR TITLE
Emit DBNull.Value instead of empty array for null image data type

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/ValueReader.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueReader.cs
@@ -184,6 +184,10 @@ namespace AdoNetCore.AseClient.Internal
                         stream.Read(textPtr, 0, textPtrLen);
                         stream.ReadULong(); //timestamp
                         var dataLen = stream.ReadInt();
+                        if (dataLen == 0)
+                        {
+                            return DBNull.Value;
+                        }
                         var data = new byte[dataLen];
                         stream.Read(data, 0, dataLen);
                         return data;

--- a/test/AdoNetCore.AseClient.Tests/Integration/Query/ImageTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Query/ImageTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using AdoNetCore.AseClient.Internal;
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration.Query
+{
+    [TestFixture]
+    [Category("basic")]
+    public class ImageTests
+    {
+        private IDbConnection GetConnection()
+        {
+            Logger.Enable();
+            return new AseConnection(ConnectionStrings.Pooled);
+        }
+
+        [TestCaseSource(nameof(SelectLiteral_Cases))]
+        public void SelectLiteral_Dapper(string query, byte[] expected)
+        {
+            using (var connection = GetConnection())
+            {
+                Assert.AreEqual(expected, connection.ExecuteScalar<byte[]>(query));
+            }
+        }
+
+        [TestCaseSource(nameof(SelectLiteral_Cases))]
+        public void SelectLiteral_ExecuteScalar(string query, object expected)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = query;
+                    Assert.AreEqual(expected ?? DBNull.Value, command.ExecuteScalar());
+                }
+            }
+        }
+
+        public static IEnumerable<TestCaseData> SelectLiteral_Cases()
+        {
+            yield return new TestCaseData("select convert(image, null)", null);
+            yield return new TestCaseData("select convert(image, 0xffffffff)", new byte[] {0xff, 0xff, 0xff, 0xff});
+        }
+    }
+}


### PR DESCRIPTION
Fixes #47 