### PR TITLE
Null vs zero-length byte arrays

### DIFF
--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -490,7 +490,9 @@ namespace AdoNetCore.AseClient
             ? DBNull.Value
             : Value is string && Equals(Value, string.Empty)
                 ? " "
-                : Value;
+                : Value is byte[] bytes && bytes.Length == 0
+                    ? new byte[] {0}
+                    : Value;
 
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Integration/Query/ImageTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Query/ImageTests.cs
@@ -1,20 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using AdoNetCore.AseClient.Internal;
+using System.Data.Common;
+using AdoNetCore.AseClient.Tests.ConnectionProvider;
 using Dapper;
 using NUnit.Framework;
 
 namespace AdoNetCore.AseClient.Tests.Integration.Query
 {
-    [TestFixture]
     [Category("basic")]
-    public class ImageTests
+#if NET_FRAMEWORK
+    [TestFixture(typeof(SapConnectionProvider))]
+#endif
+    [TestFixture(typeof(CoreFxConnectionProvider))]
+    public class ImageTests<T> where T : IConnectionProvider
     {
-        private IDbConnection GetConnection()
+        private DbConnection GetConnection()
         {
-            Logger.Enable();
-            return new AseConnection(ConnectionStrings.Pooled);
+            return Activator.CreateInstance<T>().GetConnection(ConnectionStrings.Pooled);
         }
 
         [TestCaseSource(nameof(SelectLiteral_Cases))]
@@ -44,6 +47,46 @@ namespace AdoNetCore.AseClient.Tests.Integration.Query
         {
             yield return new TestCaseData("select convert(image, null)", null);
             yield return new TestCaseData("select convert(image, 0xffffffff)", new byte[] {0xff, 0xff, 0xff, 0xff});
+        }
+
+        [TestCaseSource(nameof(TestParameter_Cases))]
+        public void SelectParameter_Dapper(object parameterValue, object expected)
+        {
+            using (var connection = GetConnection())
+            {
+                var p = new DynamicParameters();
+                p.Add("@expected", expected, DbType.Binary);
+                Assert.AreEqual(expected, connection.ExecuteScalar<byte[]>("select @expected", p));
+            }
+        }
+
+        [TestCaseSource(nameof(TestParameter_Cases))]
+        public void SelectParameter_ExecuteScalar(object parameterValue, object expected)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "select @expected";
+
+                    var p = command.CreateParameter();
+                    p.DbType = DbType.Binary;
+                    p.ParameterName = "@expected";
+                    p.Value = parameterValue ?? DBNull.Value;
+                    command.Parameters.Add(p);
+
+                    Assert.AreEqual(expected ?? DBNull.Value, command.ExecuteScalar());
+                }
+            }
+        }
+
+        public static IEnumerable<TestCaseData> TestParameter_Cases()
+        {
+            yield return new TestCaseData(null, null);
+            yield return new TestCaseData(new byte[0], new byte[] {0});
+            yield return new TestCaseData(new byte[] {0xff}, new byte[] {0xff});
         }
     }
 }


### PR DESCRIPTION
Fixes issue #57.

So it turns out that like with strings, you can't distinguish between null and zero-length byte arrays, so the driver sends a single zero-byte.

Note about fix: as part of the [`issue-51-unicode-whitespace`](https://github.com/DataAction/AdoNetCore.AseClient/tree/issue-51-unicode-whitespace) branch, [there's a refactor to this chain of ternary operators to be less ugly](https://github.com/DataAction/AdoNetCore.AseClient/commit/b29282298b9d6413ed76c8d4047ae83f9dfc20ac#diff-35518a50a686997cf7426799c4ae0136R5).