### PR TITLE
Do not throw if Dispose(disposing) is called repeatedly

### DIFF
--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -430,9 +430,11 @@ namespace AdoNetCore.AseClient
 
         protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
+
             if (_isDisposed)
             {
-                throw new ObjectDisposedException(nameof(AseCommand));
+                return;
             }
 
             _isDisposed = true;

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -119,9 +119,11 @@ namespace AdoNetCore.AseClient
         /// </summary>
         protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
+
             if (_isDisposed)
             {
-                throw new ObjectDisposedException(nameof(AseConnection));
+                return;
             }
 
             if (_transaction != null && !_transaction.IsDisposed)

--- a/src/AdoNetCore.AseClient/AseTransaction.cs
+++ b/src/AdoNetCore.AseClient/AseTransaction.cs
@@ -141,9 +141,11 @@ namespace AdoNetCore.AseClient
         /// </summary>
         protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
+
             if (_isDisposed)
             {
-                throw new ObjectDisposedException(nameof(AseTransaction));
+                return;
             }
 
             Rollback();

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseCommandTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseCommandTests.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Unit
+{
+    public class AseCommandTests
+    {
+        [Test]
+        public void RepeatedDisposal_DoesNotThrow()
+        {
+            var command = new AseCommand();
+            command.Dispose();
+            command.Dispose();
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -249,6 +249,18 @@ namespace AdoNetCore.AseClient.Tests.Unit
             Assert.AreEqual(2, eventCount); // 2 state changes occur while Opening a connection.
         }
 
+        [Test]
+        public void RepeatedDisposal_DoesNotThrow()
+        {
+            var mockConnectionPoolManager = InitMockConnectionPoolManager();
+
+            var connection = new AseConnection("Data Source=myASEserver;Port=5000;Database=foo;Uid=myUsername;Pwd=myPassword;", mockConnectionPoolManager);
+
+            connection.Open();
+            connection.Dispose();
+            connection.Dispose();
+        }
+
         private static IConnectionPoolManager InitMockConnectionPoolManager()
         {
             var mockConnection = new Mock<IInternalConnection>();

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
@@ -221,5 +221,56 @@ namespace AdoNetCore.AseClient.Tests.Unit
             mockCommandRollbackTransaction.VerifySet(x => { x.Transaction = transaction; });
             mockCommandRollbackTransaction.Verify();
         }
+
+        [Test]
+        public void RepeatedDisposal_DoesNotThrow()
+        {
+            // Arrange
+            var mockConnection = new Mock<IDbConnection>();
+            var isolationLevel = IsolationLevel.Serializable;
+
+            var mockCommandIsolationLevel = new Mock<IDbCommand>();
+            var mockCommandBeginTransaction = new Mock<IDbCommand>();
+            var mockCommandRollbackTransaction = new Mock<IDbCommand>();
+
+            mockCommandIsolationLevel
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandBeginTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandRollbackTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockConnection
+                .Setup(x => x.BeginTransaction(isolationLevel))
+                .Returns(() =>
+                {
+                    // Simulate what AseConnection.BeginTransaction() does.
+                    var t = new AseTransaction(mockConnection.Object, isolationLevel);
+                    t.Begin();
+                    return t;
+                });
+
+            mockConnection
+                .SetupSequence(x => x.CreateCommand())
+                .Returns(mockCommandIsolationLevel.Object)
+                .Returns(mockCommandBeginTransaction.Object)
+                .Returns(mockCommandRollbackTransaction.Object);
+
+
+            // Act
+            var connection = mockConnection.Object;
+            var transaction = connection.BeginTransaction(isolationLevel);
+
+            transaction.Dispose(); // Implicit rollback
+            transaction.Dispose(); // Should do nothing
+        }
     }
 }


### PR DESCRIPTION
Fixes #63 

As per the pattern described in the issue, also call `base.Dispose(disposing)` prior to anything else.