### PR TITLE
Pre release tasks

### DIFF
--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Data;
 using System.Data.Common;
@@ -213,11 +213,6 @@ namespace AdoNetCore.AseClient
         /// </summary>
         public override void Close()
         {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(AseConnection));
-            }
-
             if (State == ConnectionState.Closed)
             {
                 return;

--- a/src/AdoNetCore.AseClient/AseErrorCollection.cs
+++ b/src/AdoNetCore.AseClient/AseErrorCollection.cs
@@ -15,7 +15,13 @@ namespace AdoNetCore.AseClient
 
         internal AseErrorCollection(params AseError[] errors)
         {
-            _errors = new List<AseError>(ArrangeErrors(errors)).ToArray();
+            _errors = new AseError[errors?.Length ?? 0];
+            var idx = 0;
+            foreach (var error in ArrangeErrors(errors))
+            {
+                _errors[idx] = error;
+                idx++;
+            }
         }
 
         /// <summary>

--- a/src/AdoNetCore.AseClient/Internal/Handler/MessageTokenHandler.cs
+++ b/src/AdoNetCore.AseClient/Internal/Handler/MessageTokenHandler.cs
@@ -43,7 +43,7 @@ namespace AdoNetCore.AseClient.Internal.Handler
                         ServerName = t.ServerName,
                         SqlState = Encoding.ASCII.GetString(t.SqlState),
                         IsFromClient = false,
-                        IsInformation = false,
+                        IsInformation = !isSevere,
                         IsWarning = false,
                         LineNum = t.LineNumber
                     });

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseDataAdapterTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseDataAdapterTests.cs
@@ -1,4 +1,4 @@
-﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 using System.Collections.Generic;
 using System.Data;
 using System.Text.RegularExpressions;
@@ -14,7 +14,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         public void SetUp()
         {
             // Use SqlCommandBuilder.
-            using (var connnection = new AseConnection(ConnectionStrings.Default))
+            using (var connnection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connnection.Open();
 
@@ -129,7 +129,7 @@ END";
         public void TearDown()
         {
             // Use SqlCommandBuilder.
-            using (var connnection = new AseConnection(ConnectionStrings.Default))
+            using (var connnection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connnection.Open();
 
@@ -156,7 +156,7 @@ END";
         [Test]
         public void AseAdapter_WithAseCommandBuilder_HasInsertUpdateDeleteCommands()
         {
-            using (var connnection = new AseConnection(ConnectionStrings.Default))
+            using (var connnection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connnection.Open();
 
@@ -200,7 +200,7 @@ END";
         [TestCaseSource(nameof(DeriveParametersTestCases))]
         public void AseCommandBuilder_DeriveParameters_SetsParametersOnCommand(string procedureName)
         {
-            using (var connnection = new AseConnection(ConnectionStrings.Default))
+            using (var connnection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connnection.Open();
 
@@ -246,7 +246,7 @@ END";
         [Test]
         public void AseAdapter_WithAseCommandBuilder_CanInsertUpdateAndDelete()
         {
-            using (var connnection = new AseConnection(ConnectionStrings.Default))
+            using (var connnection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connnection.Open();
 

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseDataReaderTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseDataReaderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using NUnit.Framework;
@@ -409,7 +409,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [TestCase("IMAGE")]
         public void GetBytes_WithNullValue_ReturnsNull(string aseType)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
 
@@ -822,7 +822,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
 
         private void GetHelper_WithValue_TCastSuccessfully<T>(string columnName, Func<AseDataReader, int, T> testMethod, T expectedValue)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
 
@@ -860,7 +860,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
 
         private void GetHelper_WithValue_ThrowsException<T>(string columnName, Func<AseDataReader, int, T> testMethod, Type exceptionType)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
 
@@ -881,7 +881,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
 
         private void GetHelper_WithNullValue_ThrowsAseException<T>(string columnName, Func<AseDataReader, int, T> testMethod)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
 
@@ -913,7 +913,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [TestCase(CommandBehavior.SingleRow, 1)]
         public void ExecuteReader_WithCommandBehavior_ReturnsTheCorrectNumberOfRows(CommandBehavior behavior, int expectedNumberOfRows)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
 
@@ -952,7 +952,7 @@ SELECT 5";
         [TestCaseSource(nameof(GetFieldType_ReturnsNonNullableType_Cases))]
         public void GetFieldType_ReturnsNonNullableType(string query, Type expected)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
@@ -16,7 +16,6 @@ namespace AdoNetCore.AseClient.Tests.Integration
                 var ex = Assert.Throws<Sybase.Data.AseClient.AseException>(() => connection.Execute($"dump database {dbName} to '/doesnotexist/foo' with compression = '101'"));
                 Assert.Greater(ex.Errors.Count, 1);
                 Assert.Greater(ex.Errors[0].Severity, 10);
-                Assert.AreEqual(8009, ex.Errors[0].MessageNumber);
             }
         }
 #endif

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
@@ -31,7 +31,6 @@ namespace AdoNetCore.AseClient.Tests.Integration
                 var ex = Assert.Throws<AseException>(() => connection.Execute($"dump database {dbName} to '/doesnotexist/foo' with compression = '101'"));
                 Assert.Greater(ex.Errors.Count, 1);
                 Assert.Greater(ex.Errors[0].Severity, 10);
-                Assert.AreEqual(8009, ex.Errors[0].MessageNumber);
             }
         }
     }

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
@@ -1,0 +1,38 @@
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration
+{
+    public class AseExceptionTests
+    {
+#if NET_FRAMEWORK
+        [Test]
+        public void Execute_InvalidBackupServerCommand_ThrowsAseException_Sap()
+        {
+            using (var connection = new Sybase.Data.AseClient.AseConnection(ConnectionStrings.Pooled))
+            {
+                var dbName = connection.QuerySingle<string>("select db_name()");
+
+                var ex = Assert.Throws<Sybase.Data.AseClient.AseException>(() => connection.Execute($"dump database {dbName} to '/doesnotexist/foo' with compression = '101'"));
+                Assert.Greater(ex.Errors.Count, 1);
+                Assert.Greater(ex.Errors[0].Severity, 10);
+                Assert.AreEqual(8009, ex.Errors[0].MessageNumber);
+            }
+        }
+#endif
+
+        [Test]
+        public void Execute_InvalidBackupServerCommand_ThrowsAseException_CoreFx()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                var dbName = connection.QuerySingle<string>("select db_name()");
+
+                var ex = Assert.Throws<AseException>(() => connection.Execute($"dump database {dbName} to '/doesnotexist/foo' with compression = '101'"));
+                Assert.Greater(ex.Errors.Count, 1);
+                Assert.Greater(ex.Errors[0].Severity, 10);
+                Assert.AreEqual(8009, ex.Errors[0].MessageNumber);
+            }
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/CancelTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +19,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteNonQueryAsync_NoCancel_Succeeds()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -34,7 +34,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteNonQueryAsync_AlreadyCanceled_Cancels()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -52,7 +52,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteNonQueryAsync_DelayedCancel_Cancels()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -71,7 +71,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteQuickNonQueryAsync_DelayedCancel_DoesNothing()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -89,7 +89,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteScalarAsync_NoCancel_Succeeds()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -106,7 +106,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteScalarAsync_AlreadyCanceled_Cancels()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -124,7 +124,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteScalarAsync_DelayedCancel_Cancels()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -143,7 +143,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ExecuteQuickScalarAsync_DelayedCancel_DoesNothing()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())

--- a/test/AdoNetCore.AseClient.Tests/Integration/ChangeDatabaseTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/ChangeDatabaseTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 
 namespace AdoNetCore.AseClient.Tests.Integration
 {
@@ -9,7 +9,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void ChangeDatabase_Success()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 connection.ChangeDatabase("tempdb");

--- a/test/AdoNetCore.AseClient.Tests/Integration/ConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/ConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿using AdoNetCore.AseClient.Internal;
+using AdoNetCore.AseClient.Internal;
 using NUnit.Framework;
 
 namespace AdoNetCore.AseClient.Tests.Integration
@@ -15,7 +15,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void Ping_ShouldWork()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 Assert.IsTrue(connection.InternalConnection.Ping());

--- a/test/AdoNetCore.AseClient.Tests/Integration/DataSetTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/DataSetTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0
+#if NETCOREAPP2_0
 using System;
 using System.Data;
 using AdoNetCore.AseClient.Internal;
@@ -14,7 +14,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         public void SingleTable_Load_Succeeds()
         {
             Logger.Enable();
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             using (var command = connection.CreateCommand())
             {
                 connection.Open();

--- a/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/EchoProcedureTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
@@ -70,7 +70,7 @@ end";
         [SetUp]
         public void Setup()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_createProc);
                 connection.Execute(_createEchoCharProc);
@@ -138,7 +138,7 @@ end";
         [TestCase(null, null)]
         public void EchoChar_Procedure_ShouldExecute(object input, object expected)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -173,7 +173,7 @@ end";
         [TestCase(DbType.String)] //LONGBINARY:35(510)
         public void EchoString_Procedure_ShouldExecute(DbType outputType)
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -239,7 +239,7 @@ end";
         [TearDown]
         public void Teardown()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_dropProc);
                 connection.Execute(_dropEchoCharProc);

--- a/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -26,7 +26,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
 
         public static IEnumerable<TestCaseData> Login_Success_Cases()
         {
-            yield return new TestCaseData(ConnectionStrings.Default);
+            yield return new TestCaseData(ConnectionStrings.Pooled);
             yield return new TestCaseData(ConnectionStrings.BigPacketSize);
         }
 

--- a/test/AdoNetCore.AseClient.Tests/Integration/MultiTypeEchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/MultiTypeEchoProcedureTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using AdoNetCore.AseClient.Internal;
 using Dapper;
@@ -24,7 +24,7 @@ end";
         [SetUp]
         public void Setup()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_createProc);
             }
@@ -34,7 +34,7 @@ end";
         public void Simple_Procedure_ShouldExecute()
         {
             Logger.Enable();
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 var p = new DynamicParameters();
                 p.Add("@echoChar", null, DbType.String, ParameterDirection.Output, 2);
@@ -51,7 +51,7 @@ end";
         [TearDown]
         public void Teardown()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_dropProc);
             }

--- a/test/AdoNetCore.AseClient.Tests/Integration/RaiserrorProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/RaiserrorProcedureTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using Dapper;
 using NUnit.Framework;
 
@@ -21,7 +21,7 @@ end";
         [SetUp]
         public void Setup()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_createProc);
             }
@@ -30,7 +30,7 @@ end";
         [Test]
         public void RaiserrorProcedure_ThrowsAseException()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 var ex = Assert.Throws<AseException>(() => connection.Execute("sp_test_raiseerror", commandType: CommandType.StoredProcedure));
                 var error = ex.Errors[0];
@@ -46,7 +46,7 @@ end";
         [TearDown]
         public void Teardown()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_dropProc);
             }

--- a/test/AdoNetCore.AseClient.Tests/Integration/SimpleProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/SimpleProcedureTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using Dapper;
 using NUnit.Framework;
 
@@ -14,7 +14,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [SetUp]
         public void Setup()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_createProc);
             }
@@ -23,7 +23,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [Test]
         public void Simple_Procedure_ShouldExecute()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute("sp_test_simple", commandType: CommandType.StoredProcedure);
             }
@@ -32,7 +32,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
         [TearDown]
         public void Teardown()
         {
-            using (var connection = new AseConnection(ConnectionStrings.Default))
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
                 connection.Execute(_dropProc);
             }

--- a/test/AdoNetCore.AseClient.Tests/Integration/TestEnvironmentHealthTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TestEnvironmentHealthTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 
 namespace AdoNetCore.AseClient.Tests.Integration

--- a/test/AdoNetCore.AseClient.Tests/Unit/MessageTokenHandlerTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/MessageTokenHandlerTests.cs
@@ -94,9 +94,9 @@ namespace AdoNetCore.AseClient.Tests.Unit
             Assert.IsFalse(ex.Errors[1].IsError);
             Assert.IsTrue(ex.Errors[1].IsInformation);
 
-            Assert.AreEqual(2, ex.Errors[1].Severity);
-            Assert.IsFalse(ex.Errors[1].IsError);
-            Assert.IsTrue(ex.Errors[1].IsInformation);
+            Assert.AreEqual(2, ex.Errors[2].Severity);
+            Assert.IsFalse(ex.Errors[2].IsError);
+            Assert.IsTrue(ex.Errors[2].IsInformation);
         }
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Unit/MessageTokenHandlerTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/MessageTokenHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using AdoNetCore.AseClient.Enum;
+using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Internal.Handler;
 using AdoNetCore.AseClient.Token;
 using NUnit.Framework;
@@ -88,6 +88,15 @@ namespace AdoNetCore.AseClient.Tests.Unit
             });
             var ex = Assert.Throws<AseException>(() => handler.AssertNoErrors());
             Assert.AreEqual(3, ex.Errors.Count);
+            Assert.AreEqual(16, ex.Errors[0].Severity);
+
+            Assert.AreEqual(1, ex.Errors[1].Severity);
+            Assert.IsFalse(ex.Errors[1].IsError);
+            Assert.IsTrue(ex.Errors[1].IsInformation);
+
+            Assert.AreEqual(2, ex.Errors[1].Severity);
+            Assert.IsFalse(ex.Errors[1].IsError);
+            Assert.IsTrue(ex.Errors[1].IsInformation);
         }
     }
 }


### PR DESCRIPTION
Relates to issue #75 

* Fix `ObjectDisposedException` issue which was occurring in `netcore1.0` and `netcore1.1`
* Updated test cases related to backupserver `AseException`/`AseError` stuff, turns out that Errors[0] needs to be the most severe error, so altered that stuff slightly.
* My OS was running out of ports to run tests with, so I've switched more of the test cases over to using a Pooled connection string to hopefully alleviate this.