### PR TITLE
Infer AseDbType prior to calculating what what to send to the server

### DIFF
--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -23,9 +23,6 @@ namespace AdoNetCore.AseClient
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private AseDbType _type;
 
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private bool _isDbTypeSetExplicitly;
-
         /// <summary>
         /// Constructor function for an <see cref="AseParameter" />instance.
         /// </summary>
@@ -283,7 +280,6 @@ namespace AdoNetCore.AseClient
         public override void ResetDbType()
         {
             DbType = default(DbType);
-            _isDbTypeSetExplicitly = false;
         }
 
         /// <summary>
@@ -307,16 +303,8 @@ namespace AdoNetCore.AseClient
             get => _type;
             set {
                 _type = TypeMap.CleanupAseDbType(value);
-                _isDbTypeSetExplicitly = true;
             }
         }
-
-        /// <summary>
-        /// Indicates if the DbType is known, or if we need to infer it
-        /// </summary>
-        internal bool DbTypeIsKnown => _isDbTypeSetExplicitly ||
-                                       //DbType default is AnsiString (0), so if Value is string/char, that's good enough. If the user requires unicode strings, they should explicitly specify an appropriate DbType
-                                       (DbType == default(DbType) && (Value is string || Value is char || Value == null || Value == DBNull.Value));
 
         /// <summary>
         /// Gets or sets a value that indicates whether the parameter is input-only, output-only, 
@@ -467,7 +455,6 @@ namespace AdoNetCore.AseClient
             var clone = new AseParameter
             {
                 _type = AseDbType,
-                _isDbTypeSetExplicitly = _isDbTypeSetExplicitly,
                 Direction = Direction,
                 IsNullable = IsNullable,
                 ParameterName = ParameterName,

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -50,6 +50,8 @@ namespace AdoNetCore.AseClient.Internal
 
         public static FormatItem CreateForParameter(AseParameter parameter, DbEnvironment env)
         {
+            parameter.AseDbType = TypeMap.InferType(parameter);
+
             var dbType = parameter.DbType;
             var length = TypeMap.GetFormatLength(dbType, parameter, env.Encoding);
             var format = new FormatItem
@@ -58,7 +60,7 @@ namespace AdoNetCore.AseClient.Internal
                 IsOutput = parameter.IsOutput,
                 IsNullable = parameter.IsNullable,
                 Length = length,
-                DataType = TypeMap.GetTdsDataType(dbType, parameter.DbTypeIsKnown, parameter.SendableValue, length, parameter.ParameterName),
+                DataType = TypeMap.GetTdsDataType(dbType, parameter.SendableValue, length, parameter.ParameterName),
                 UserType = TypeMap.GetTdsUserType(dbType),
             };
 

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -53,7 +53,7 @@ namespace AdoNetCore.AseClient.Internal
             {typeof(string), AseDbType.VarChar},
             {typeof(byte[]), AseDbType.VarBinary},
             {typeof(Guid), AseDbType.VarBinary},
-            {typeof(decimal), AseDbType.Decimal},
+            {typeof(decimal), AseDbType.Numeric},
             {typeof(AseDecimal), AseDbType.Decimal},
             {typeof(float), AseDbType.Real},
             {typeof(double), AseDbType.Double},

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -41,6 +41,7 @@ namespace AdoNetCore.AseClient.Internal
         {
             {typeof(bool), AseDbType.Bit},
             {typeof(byte), AseDbType.TinyInt},
+            {typeof(sbyte), AseDbType.SmallInt},
             {typeof(short), AseDbType.SmallInt},
             {typeof(ushort), AseDbType.UnsignedSmallInt},
             {typeof(int), AseDbType.Integer},

--- a/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
@@ -26,13 +26,19 @@ namespace AdoNetCore.AseClient.Internal
             {
                 typeof(TimeSpan), new Dictionary<Type, Func<object, Encoding, object>>
                 {
-                    {typeof(DateTime), (o, _) => Constants.Sql.RegularDateTime.Epoch + (TimeSpan)o }
+                    {typeof(DateTime), (o, _) => Constants.Sql.RegularDateTime.Epoch + (TimeSpan) o}
                 }
             },
             {
                 typeof(string), new Dictionary<Type, Func<object, Encoding, object>>
                 {
                     {typeof(byte[]), (o, e) => e.GetBytes((string) o)}
+                }
+            },
+            {
+                typeof(char[]), new Dictionary<Type, Func<object, Encoding, object>>
+                {
+                    {typeof(string), (o, e) => new string((char[]) o)}
                 }
             }
         };

--- a/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
+++ b/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
@@ -13,7 +13,7 @@ namespace AdoNetCore.AseClient.Tests
         public static string Pooled =>        $"{Prefix}; Pooling=true;  LoginTimeOut=1; Max Pool Size=32;";
         public static string Pooled10 =>      $"{Prefix}; Pooling=true;  LoginTimeOut=1; Max Pool Size=10;";
         public static string Pooled100 =>     $"{Prefix}; Pooling=true;  LoginTimeOut=1; Max Pool Size=100;";
-        public static string PooledUtf8 =>    Pooled;//$"{Prefix}; Pooling=true;  LoginTimeOut=1; Max Pool Size=32; charset=utf8";
+        public static string PooledUtf8 =>    Pooled;
         public static string Cp850 =>         $"{Prefix}; charset=cp850;";
         public static string BigPacketSize => $"{Prefix}; Pooling=false; LoginTimeOut=1; PacketSize=2048;";
         public static string BigTextSize =>   $"{Prefix}; Pooling=false; LoginTimeOut=1; TextSize=131072;";

--- a/test/AdoNetCore.AseClient.Tests/Integration/Query/InferenceTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Query/InferenceTests.cs
@@ -14,15 +14,15 @@ namespace AdoNetCore.AseClient.Tests.Integration.Query
     [TestFixture(typeof(CoreFxConnectionProvider))]
     public class InferenceTests<T> where T : IConnectionProvider
     {
-        private DbConnection GetConnection()
+        private DbConnection GetConnection(bool aseDecimal)
         {
-            return Activator.CreateInstance<T>().GetConnection(ConnectionStrings.PooledUtf8);
+            return Activator.CreateInstance<T>().GetConnection(aseDecimal ? ConnectionStrings.AseDecimalOn: ConnectionStrings.PooledUtf8);
         }
 
         [TestCaseSource(nameof(Select_UntypedParameter_ReturnsSameValue_Cases))]
-        public void Select_UntypedParameter_ReturnsSameValue(object input, object expected)
+        public void Select_UntypedParameter_ReturnsSameValue(object input, object expected, int aseDbType)
         {
-            using (var connection = GetConnection())
+            using (var connection = GetConnection(input is AseDecimal))
             {
                 connection.Open();
                 using (var command = connection.CreateCommand())
@@ -34,42 +34,48 @@ namespace AdoNetCore.AseClient.Tests.Integration.Query
                     {
                         cSap.Parameters.Add(new Sybase.Data.AseClient.AseParameter("@input", input));
                         Assert.AreEqual(Sybase.Data.AseClient.AseDbType.Unsupported, cSap.Parameters[0].AseDbType);
+                        Assert.AreEqual(expected, command.ExecuteScalar());
+                        Assert.AreEqual((Sybase.Data.AseClient.AseDbType) aseDbType, cSap.Parameters[0].AseDbType);
                     }
 #endif
                     if (command is AseCommand cCore)
                     {
                         cCore.Parameters.Add(new AseParameter("@input", input));
                         Assert.AreEqual(AseDbType.Unsupported, cCore.Parameters[0].AseDbType);
+                        Assert.AreEqual(expected, command.ExecuteScalar());
+                        Assert.AreEqual((AseDbType) aseDbType, cCore.Parameters[0].AseDbType);
                     }
-
-                    Assert.AreEqual(expected, command.ExecuteScalar());
                 }
             }
         }
 
         public static IEnumerable<TestCaseData> Select_UntypedParameter_ReturnsSameValue_Cases()
         {
-            yield return new TestCaseData("master", "master");
-            yield return new TestCaseData(new DateTime(2018, 11, 08, 11, 59, 59), new DateTime(2018, 11, 08, 11, 59, 59));
-            yield return new TestCaseData(byte.MaxValue, byte.MaxValue);
-            yield return new TestCaseData(short.MaxValue, short.MaxValue);
-            yield return new TestCaseData(ushort.MaxValue, ushort.MaxValue);
-            yield return new TestCaseData(int.MaxValue, int.MaxValue);
-            yield return new TestCaseData(uint.MaxValue, uint.MaxValue);
-            yield return new TestCaseData(long.MaxValue, long.MaxValue);
-            yield return new TestCaseData(ulong.MaxValue, ulong.MaxValue);
-            yield return new TestCaseData(1m, 1m);
-            yield return new TestCaseData(float.MaxValue, float.MaxValue);
-            yield return new TestCaseData(double.MaxValue, double.MaxValue);
-            yield return new TestCaseData(true, true);
+            yield return new TestCaseData("master", "master", AseDbType.VarChar);
+            yield return new TestCaseData('a', "a", AseDbType.VarChar);
+            yield return new TestCaseData(new DateTime(2018, 11, 08, 11, 59, 59), new DateTime(2018, 11, 08, 11, 59, 59), AseDbType.DateTime);
+            yield return new TestCaseData(byte.MaxValue, byte.MaxValue, AseDbType.TinyInt);
+            yield return new TestCaseData(short.MaxValue, short.MaxValue, AseDbType.SmallInt);
+            yield return new TestCaseData(ushort.MaxValue, ushort.MaxValue, AseDbType.UnsignedSmallInt);
+            yield return new TestCaseData(int.MaxValue, int.MaxValue, AseDbType.Integer);
+            yield return new TestCaseData(uint.MaxValue, uint.MaxValue, AseDbType.UnsignedInt);
+            yield return new TestCaseData(long.MaxValue, long.MaxValue, AseDbType.BigInt);
+            yield return new TestCaseData(ulong.MaxValue, ulong.MaxValue, AseDbType.UnsignedBigInt);
+            yield return new TestCaseData(1.111m, 1.111m, AseDbType.Numeric);
+            yield return new TestCaseData(float.MaxValue, float.MaxValue, AseDbType.Real);
+            yield return new TestCaseData(double.MaxValue, double.MaxValue, AseDbType.Double);
+            yield return new TestCaseData(true, true, AseDbType.Bit);
 
             if (typeof(T) == typeof(CoreFxConnectionProvider))
             {
-                yield return new TestCaseData(new TimeSpan(11, 59, 59), new DateTime(1900, 01, 01, 11, 59, 59));
+                yield return new TestCaseData(new TimeSpan(11, 59, 59), new DateTime(1900, 01, 01, 11, 59, 59), AseDbType.DateTime);
                 var guid = Guid.NewGuid();
-                yield return new TestCaseData(guid, guid.ToByteArray());
-                yield return new TestCaseData(new byte[] { 0x01 }, new byte[] { 0x01 });
-                yield return new TestCaseData(sbyte.MaxValue, sbyte.MaxValue);
+                yield return new TestCaseData(guid, guid.ToByteArray(), AseDbType.VarBinary);
+                yield return new TestCaseData(new byte[] { 0x01 }, new byte[] { 0x01 }, AseDbType.VarBinary);
+                yield return new TestCaseData(sbyte.MaxValue, sbyte.MaxValue, AseDbType.SmallInt);
+                yield return new TestCaseData(new [] {'a'}, "a", AseDbType.VarChar);
+                // reference driver throws NotSupportedException
+                yield return new TestCaseData(new AseDecimal(2.111m), new AseDecimal(2.111m), AseDbType.Decimal);
             }
         }
     }

--- a/test/AdoNetCore.AseClient.Tests/Integration/Query/InferenceTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Query/InferenceTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using AdoNetCore.AseClient.Tests.ConnectionProvider;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration.Query
+{
+    [Category("basic")]
+#if NET_FRAMEWORK
+    [TestFixture(typeof(SapConnectionProvider))]
+#endif
+    [TestFixture(typeof(CoreFxConnectionProvider))]
+    public class InferenceTests<T> where T : IConnectionProvider
+    {
+        private DbConnection GetConnection()
+        {
+            return Activator.CreateInstance<T>().GetConnection(ConnectionStrings.PooledUtf8);
+        }
+
+        [TestCaseSource(nameof(Select_UntypedParameter_ReturnsSameValue_Cases))]
+        public void Select_UntypedParameter_ReturnsSameValue(object input, object expected)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "select @input";
+                    command.CommandType = CommandType.Text;
+#if NET_FRAMEWORK
+                    if (command is Sybase.Data.AseClient.AseCommand cSap)
+                    {
+                        cSap.Parameters.Add(new Sybase.Data.AseClient.AseParameter("@input", input));
+                        Assert.AreEqual(Sybase.Data.AseClient.AseDbType.Unsupported, cSap.Parameters[0].AseDbType);
+                    }
+#endif
+                    if (command is AseCommand cCore)
+                    {
+                        cCore.Parameters.Add(new AseParameter("@input", input));
+                        Assert.AreEqual(AseDbType.Unsupported, cCore.Parameters[0].AseDbType);
+                    }
+
+                    Assert.AreEqual(expected, command.ExecuteScalar());
+                }
+            }
+        }
+
+        public static IEnumerable<TestCaseData> Select_UntypedParameter_ReturnsSameValue_Cases()
+        {
+            yield return new TestCaseData("master", "master");
+            yield return new TestCaseData(new DateTime(2018, 11, 08, 11, 59, 59), new DateTime(2018, 11, 08, 11, 59, 59));
+            yield return new TestCaseData(byte.MaxValue, byte.MaxValue);
+            yield return new TestCaseData(short.MaxValue, short.MaxValue);
+            yield return new TestCaseData(ushort.MaxValue, ushort.MaxValue);
+            yield return new TestCaseData(int.MaxValue, int.MaxValue);
+            yield return new TestCaseData(uint.MaxValue, uint.MaxValue);
+            yield return new TestCaseData(long.MaxValue, long.MaxValue);
+            yield return new TestCaseData(ulong.MaxValue, ulong.MaxValue);
+            yield return new TestCaseData(1m, 1m);
+            yield return new TestCaseData(float.MaxValue, float.MaxValue);
+            yield return new TestCaseData(double.MaxValue, double.MaxValue);
+            yield return new TestCaseData(true, true);
+
+            if (typeof(T) == typeof(CoreFxConnectionProvider))
+            {
+                yield return new TestCaseData(new TimeSpan(11, 59, 59), new DateTime(1900, 01, 01, 11, 59, 59));
+                var guid = Guid.NewGuid();
+                yield return new TestCaseData(guid, guid.ToByteArray());
+                yield return new TestCaseData(new byte[] { 0x01 }, new byte[] { 0x01 });
+            }
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/Query/InferenceTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Query/InferenceTests.cs
@@ -69,6 +69,7 @@ namespace AdoNetCore.AseClient.Tests.Integration.Query
                 var guid = Guid.NewGuid();
                 yield return new TestCaseData(guid, guid.ToByteArray());
                 yield return new TestCaseData(new byte[] { 0x01 }, new byte[] { 0x01 });
+                yield return new TestCaseData(sbyte.MaxValue, sbyte.MaxValue);
             }
         }
     }


### PR DESCRIPTION
Fixes issue #96 

Note: the type will only be inferred if it is not set explicitly