### PR TITLE
Add ability to receive results sets immediately.

### DIFF
--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -232,7 +232,8 @@ namespace AdoNetCore.AseClient
                 throw new ObjectDisposedException(nameof(AseConnection));
             }
 
-            var aseCommand = new AseCommand(this) { NamedParameters = NamedParameters };
+            _eventNotifier?.ClearResultHandlers();
+            var aseCommand = new AseCommand(this) { NamedParameters = NamedParameters, EventNotifier = _eventNotifier };
 
             return aseCommand;
         }

--- a/src/AdoNetCore.AseClient/AseDataReader.cs
+++ b/src/AdoNetCore.AseClient/AseDataReader.cs
@@ -1,32 +1,32 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Data;
 using System.Text;
 using System.Data.Common;
-using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Internal;
 
 namespace AdoNetCore.AseClient
 {
     public sealed class AseDataReader : DbDataReader
     {
-        private static readonly HashSet<TdsDataType> LongTdsTypes = new HashSet<TdsDataType> {TdsDataType.TDS_BLOB, TdsDataType.TDS_IMAGE, TdsDataType.TDS_LONGBINARY, TdsDataType.TDS_LONGCHAR, TdsDataType.TDS_TEXT, TdsDataType.TDS_UNITEXT};
+        //private static readonly HashSet<TdsDataType> LongTdsTypes = new HashSet<TdsDataType> {TdsDataType.TDS_BLOB, TdsDataType.TDS_IMAGE, TdsDataType.TDS_LONGBINARY, TdsDataType.TDS_LONGCHAR, TdsDataType.TDS_TEXT, TdsDataType.TDS_UNITEXT};
 
         private readonly TableResult[] _results;
         private int _currentResult = -1;
         private int _currentRow = -1;
-        private readonly AseCommand _command;
         private readonly CommandBehavior _behavior;
 
 #if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
+        private readonly AseCommand _command;
         private DataTable _currentSchemaTable;
 #endif
 
         internal AseDataReader(TableResult[] results, AseCommand command, CommandBehavior behavior)
         {
             _results = results;
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
             _command = command;
+#endif
             _behavior = behavior;
             NextResult();
         }

--- a/src/AdoNetCore.AseClient/AseException.cs
+++ b/src/AdoNetCore.AseClient/AseException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 #if ENABLE_SYSTEMEXCEPTION
 using System.Runtime.Serialization;
 #endif

--- a/src/AdoNetCore.AseClient/Enum/ReaderSourceType.cs
+++ b/src/AdoNetCore.AseClient/Enum/ReaderSourceType.cs
@@ -1,0 +1,8 @@
+﻿namespace AdoNetCore.AseClient.Enum
+{
+    internal enum ReaderSourceType
+    {
+        Standard = 0,
+        ForCallback
+    }
+}

--- a/src/AdoNetCore.AseClient/IAseDataEventReader.cs
+++ b/src/AdoNetCore.AseClient/IAseDataEventReader.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Data;
+
+namespace AdoNetCore.AseClient
+{
+    public interface IAseDataCallbackReader
+    {
+        bool GetBoolean(int i);
+        byte GetByte(int i);
+        long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferOffset, int length);
+        char GetChar(int i);
+        long GetChars(int i, long fieldOffset, char[] buffer, int bufferoffset, int length);
+        string GetDataTypeName(int ordinal);
+        DateTime GetDateTime(int i);
+        TimeSpan GetTimeSpan(int i);
+        decimal GetDecimal(int i);
+        double GetDouble(int i);
+        Type GetFieldType(int i);
+        float GetFloat(int i);
+        Guid GetGuid(int i);
+        short GetInt16(int i);
+        int GetInt32(int i);
+        long GetInt64(int i);
+        ushort GetUInt16(int i);
+        uint GetUInt32(int i);
+        ulong GetUInt64(int i);
+        string GetString(int i);
+        //AseDecimal GetAseDecimal(int ordinal);
+        string GetName(int i);
+        int GetOrdinal(string name);
+        object GetValue(int i);
+        int GetValues(object[] values);
+        bool IsDBNull(int i);
+        int FieldCount { get; }
+        int VisibleFieldCount { get; }
+        object this[int ordinal] { get; }
+        object this[string name] { get; }
+        DataTable GetSchemaTable();
+        int Depth { get; }
+        bool ContainsListCollection { get; }
+    }
+}

--- a/src/AdoNetCore.AseClient/Interface/IConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionPool.cs
@@ -1,11 +1,11 @@
-﻿namespace AdoNetCore.AseClient.Interface
+namespace AdoNetCore.AseClient.Interface
 {
     internal interface IConnectionPool
     {
         /// <summary>
         /// Attempt to reserve an internal connection in the pool for use
         /// </summary>
-        IInternalConnection Reserve();
+        IInternalConnection Reserve(IInfoMessageEventNotifier eventNotifier);
         /// <summary>
         /// Release a used internal connection back into the pool for reuse or replacement
         /// </summary>

--- a/src/AdoNetCore.AseClient/Interface/IConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionPool.cs
@@ -1,11 +1,11 @@
-namespace AdoNetCore.AseClient.Interface
+﻿namespace AdoNetCore.AseClient.Interface
 {
     internal interface IConnectionPool
     {
         /// <summary>
         /// Attempt to reserve an internal connection in the pool for use
         /// </summary>
-        IInternalConnection Reserve(IInfoMessageEventNotifier eventNotifier);
+        IInternalConnection Reserve(IEventNotifier eventNotifier);
         /// <summary>
         /// Release a used internal connection back into the pool for reuse or replacement
         /// </summary>

--- a/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
@@ -1,8 +1,8 @@
-﻿namespace AdoNetCore.AseClient.Interface
+namespace AdoNetCore.AseClient.Interface
 {
     internal interface IConnectionPoolManager
     {
-        IInternalConnection Reserve(string connectionString, IConnectionParameters parameters);
+        IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier);
         void Release(string connectionString, IInternalConnection connection);
         void ClearPool(string connectionString);
     }

--- a/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
@@ -1,8 +1,8 @@
-namespace AdoNetCore.AseClient.Interface
+﻿namespace AdoNetCore.AseClient.Interface
 {
     internal interface IConnectionPoolManager
     {
-        IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier);
+        IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IEventNotifier eventNotifier);
         void Release(string connectionString, IInternalConnection connection);
         void ClearPool(string connectionString);
     }

--- a/src/AdoNetCore.AseClient/Interface/IEventNotifier.cs
+++ b/src/AdoNetCore.AseClient/Interface/IEventNotifier.cs
@@ -7,6 +7,12 @@ namespace AdoNetCore.AseClient.Interface
         void NotifyInfoMessage(AseErrorCollection errors, string message);
     }
 
+    internal interface IResultsMessageEventNotifier
+    {
+        void NotifyResultSet();
+        void NotifyResultRow(IAseDataCallbackReader reader);
+    }
+
     internal interface IStateChangeEventNotifier
     {
         void NotifyStateChange(ConnectionState originalState, ConnectionState currentState);
@@ -16,18 +22,23 @@ namespace AdoNetCore.AseClient.Interface
     {
         void NotifyTraceEnter(object source, string method, params object[] parameters);
     }
+
     internal interface ITraceExitEventNotifier
     {
         void NotifyTraceExit(object source, string method, object returnValue);
     }
 
-    internal interface IEventNotifier : IInfoMessageEventNotifier, IStateChangeEventNotifier, ITraceEnterEventNotifier, ITraceExitEventNotifier
+    internal interface IEventNotifier : IInfoMessageEventNotifier, IStateChangeEventNotifier, ITraceEnterEventNotifier, ITraceExitEventNotifier, IResultsMessageEventNotifier
     {
         event AseInfoMessageEventHandler InfoMessage;
         event StateChangeEventHandler StateChange;
         event TraceEnterEventHandler TraceEnter;
         event TraceExitEventHandler TraceExit;
 
+        ResultSetCallbackHandler ResultSet { set; }
+        ResultRowCallbackHandler ResultRow { set; }
+
         void ClearAll();
+        void ClearResultHandlers();
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/IEventNotifier.cs
+++ b/src/AdoNetCore.AseClient/Interface/IEventNotifier.cs
@@ -1,0 +1,33 @@
+using System.Data;
+
+namespace AdoNetCore.AseClient.Interface
+{
+    internal interface IInfoMessageEventNotifier
+    {
+        void NotifyInfoMessage(AseErrorCollection errors, string message);
+    }
+
+    internal interface IStateChangeEventNotifier
+    {
+        void NotifyStateChange(ConnectionState originalState, ConnectionState currentState);
+    }
+
+    internal interface ITraceEnterEventNotifier
+    {
+        void NotifyTraceEnter(object source, string method, params object[] parameters);
+    }
+    internal interface ITraceExitEventNotifier
+    {
+        void NotifyTraceExit(object source, string method, object returnValue);
+    }
+
+    internal interface IEventNotifier : IInfoMessageEventNotifier, IStateChangeEventNotifier, ITraceEnterEventNotifier, ITraceExitEventNotifier
+    {
+        event AseInfoMessageEventHandler InfoMessage;
+        event StateChangeEventHandler StateChange;
+        event TraceEnterEventHandler TraceEnter;
+        event TraceExitEventHandler TraceExit;
+
+        void ClearAll();
+    }
+}

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -110,5 +110,10 @@ namespace AdoNetCore.AseClient.Interface
         /// </summary>
         /// <returns>An <see cref="IDictionary"/> which should under-the-hood map statistic names <see cref="string"/> to statistic values <see cref="long"/></returns>
         IDictionary RetrieveStatistics();
+
+        /// <summary>
+        /// The 'caller event' notifier for the connection
+        /// </summary>
+        IInfoMessageEventNotifier EventNotifier { get; set; }
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -63,6 +63,14 @@ namespace AdoNetCore.AseClient.Interface
         DbDataReader ExecuteReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
 
         /// <summary>
+        /// Additional implementation of a reader. This requires the <see cref="AseCommand"/> delefates <see cref="ResultRowCallbackHandler"/> and/or <see cref="ResultSetCallbackHandler"/> to fetch rows and to be notified of subsequent result sets.
+        /// Rows and new result sets are fetched while the command is running, before this method returns, and, if running a stored procedure, before any stored proc result parameter is available.
+        /// NOTE: Do not attempt to read any stored procedure return value parameter until after this method returns.
+        /// </summary>
+        void ExecuteCallbackReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction, ResultRowCallbackHandler resultRowHandler, ResultSetCallbackHandler resultSetHandler = null);
+        //void ExecuteEventReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction);
+
+        /// <summary>
         /// Internal implementation of <see cref="IDbCommand.ExecuteReader()"/>,
         /// but the result is wrapped in a Task to allow the caller to check IsCanceled
         /// </summary>
@@ -114,6 +122,6 @@ namespace AdoNetCore.AseClient.Interface
         /// <summary>
         /// The 'caller event' notifier for the connection
         /// </summary>
-        IInfoMessageEventNotifier EventNotifier { get; set; }
+        IEventNotifier EventNotifier { get; set; }
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnectionFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AdoNetCore.AseClient.Interface
@@ -9,6 +9,6 @@ namespace AdoNetCore.AseClient.Interface
         /// Create a new internal connection, ready to use.
         /// If cancellation is requested, this will discard any work done and throw an OperationCancelledException
         /// </summary>
-        Task<IInternalConnection> GetNewConnection(CancellationToken token);
+        Task<IInternalConnection> GetNewConnection(CancellationToken token, IInfoMessageEventNotifier eventNotifier);
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnectionFactory.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace AdoNetCore.AseClient.Interface
@@ -9,6 +9,6 @@ namespace AdoNetCore.AseClient.Interface
         /// Create a new internal connection, ready to use.
         /// If cancellation is requested, this will discard any work done and throw an OperationCancelledException
         /// </summary>
-        Task<IInternalConnection> GetNewConnection(CancellationToken token, IInfoMessageEventNotifier eventNotifier);
+        Task<IInternalConnection> GetNewConnection(CancellationToken token, IEventNotifier eventNotifier);
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/ISocket.cs
+++ b/src/AdoNetCore.AseClient/Interface/ISocket.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using AdoNetCore.AseClient.Internal;
 
 namespace AdoNetCore.AseClient.Interface
@@ -7,7 +8,9 @@ namespace AdoNetCore.AseClient.Interface
     {
         void SendPacket(IPacket packet, DbEnvironment env);
 
-        IToken[] ReceiveTokens(DbEnvironment env);
+        IEnumerable<IToken> ReceiveTokens(DbEnvironment env);
+
+        IEnumerable<IToken> ReceivePartialTokens(DbEnvironment env);
 
         DateTime LastActive { get; }
     }

--- a/src/AdoNetCore.AseClient/Interface/IToken.cs
+++ b/src/AdoNetCore.AseClient/Interface/IToken.cs
@@ -8,6 +8,6 @@ namespace AdoNetCore.AseClient.Interface
     {
         TokenType Type { get; }
         void Write(Stream stream, DbEnvironment env);
-        void Read(Stream stream, DbEnvironment env, IFormatToken previousFormatToken);
+        void Read(Stream stream, DbEnvironment env, IFormatToken previousFormatToken, ref bool streamExceeded);
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/ITokenParser.cs
+++ b/src/AdoNetCore.AseClient/Interface/ITokenParser.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using AdoNetCore.AseClient.Internal;
 
 namespace AdoNetCore.AseClient.Interface
@@ -8,6 +9,8 @@ namespace AdoNetCore.AseClient.Interface
     /// </summary>
     internal interface ITokenParser
     {
-        IToken[] Parse(Stream stream, DbEnvironment env);
+        long LastStartPosition { get; }
+
+        IEnumerable<IToken> Parse(Stream stream, DbEnvironment env, out bool streamExceeded);
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
@@ -43,7 +43,7 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
-        public IInternalConnection Reserve(IInfoMessageEventNotifier eventNotifier)
+        public IInternalConnection Reserve(IEventNotifier eventNotifier)
         {
             try
             {
@@ -109,7 +109,7 @@ namespace AdoNetCore.AseClient.Internal
                 : new AseException("Timed out trying to establish a connection");
         }
 
-        private async Task<IInternalConnection> ReservePooledConnection(CancellationToken cancellationToken, IInfoMessageEventNotifier eventNotifier)
+        private async Task<IInternalConnection> ReservePooledConnection(CancellationToken cancellationToken, IEventNotifier eventNotifier)
         {
             return FetchIdlePooledConnection(eventNotifier)
                    ?? (CheckAndIncrementPoolSize()
@@ -119,7 +119,7 @@ namespace AdoNetCore.AseClient.Internal
                        : WaitForPooledConnection(cancellationToken, eventNotifier));
         }
 
-        private IInternalConnection FetchIdlePooledConnection(IInfoMessageEventNotifier eventNotifier)
+        private IInternalConnection FetchIdlePooledConnection(IEventNotifier eventNotifier)
         {
             var now = DateTime.UtcNow;
             while (_available.TryTake(out var connection))
@@ -145,7 +145,7 @@ namespace AdoNetCore.AseClient.Internal
             return null;
         }
 
-        private async Task<IInternalConnection> CreateNewPooledConnection(CancellationToken cancellationToken, IInfoMessageEventNotifier eventNotifier)
+        private async Task<IInternalConnection> CreateNewPooledConnection(CancellationToken cancellationToken, IEventNotifier eventNotifier)
         {
             try
             {
@@ -160,7 +160,7 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
-        private IInternalConnection WaitForPooledConnection(CancellationToken cancellationToken, IInfoMessageEventNotifier eventNotifier)
+        private IInternalConnection WaitForPooledConnection(CancellationToken cancellationToken, IEventNotifier eventNotifier)
         {
             Logger.Instance?.WriteLine($"{nameof(WaitForPooledConnection)} start");
             try

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
@@ -43,7 +43,7 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
-        public IInternalConnection Reserve()
+        public IInternalConnection Reserve(IInfoMessageEventNotifier eventNotifier)
         {
             try
             {
@@ -53,8 +53,8 @@ namespace AdoNetCore.AseClient.Internal
                     src.CancelAfter(TimeSpan.FromSeconds(_parameters.LoginTimeout));
 
                     var task = _parameters.Pooling
-                        ? ReservePooledConnection(t)
-                        : _connectionFactory.GetNewConnection(t);
+                        ? ReservePooledConnection(t, eventNotifier)
+                        : _connectionFactory.GetNewConnection(t, eventNotifier);
 
                     task.Wait(t);
                     var connection = task.Result;
@@ -109,17 +109,17 @@ namespace AdoNetCore.AseClient.Internal
                 : new AseException("Timed out trying to establish a connection");
         }
 
-        private async Task<IInternalConnection> ReservePooledConnection(CancellationToken cancellationToken)
+        private async Task<IInternalConnection> ReservePooledConnection(CancellationToken cancellationToken, IInfoMessageEventNotifier eventNotifier)
         {
-            return FetchIdlePooledConnection()
+            return FetchIdlePooledConnection(eventNotifier)
                    ?? (CheckAndIncrementPoolSize()
                        //there's room in the pool! create new connection and return it
-                       ? await CreateNewPooledConnection(cancellationToken)
+                       ? await CreateNewPooledConnection(cancellationToken, eventNotifier)
                        //pool's full, wait for something to release a connection
-                       : WaitForPooledConnection(cancellationToken));
+                       : WaitForPooledConnection(cancellationToken, eventNotifier));
         }
 
-        private IInternalConnection FetchIdlePooledConnection()
+        private IInternalConnection FetchIdlePooledConnection(IInfoMessageEventNotifier eventNotifier)
         {
             var now = DateTime.UtcNow;
             while (_available.TryTake(out var connection))
@@ -137,6 +137,7 @@ namespace AdoNetCore.AseClient.Internal
                 }
 
                 Logger.Instance?.WriteLine($"{nameof(FetchIdlePooledConnection)} returned idle connection");
+                connection.EventNotifier = eventNotifier;
                 return connection;
             }
 
@@ -144,12 +145,12 @@ namespace AdoNetCore.AseClient.Internal
             return null;
         }
 
-        private async Task<IInternalConnection> CreateNewPooledConnection(CancellationToken cancellationToken)
+        private async Task<IInternalConnection> CreateNewPooledConnection(CancellationToken cancellationToken, IInfoMessageEventNotifier eventNotifier)
         {
             try
             {
                 Logger.Instance?.WriteLine($"{nameof(CreateNewPooledConnection)} start");
-                return await _connectionFactory.GetNewConnection(cancellationToken);
+                return await _connectionFactory.GetNewConnection(cancellationToken, eventNotifier);
             }
             catch
             {
@@ -159,13 +160,14 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
-        private IInternalConnection WaitForPooledConnection(CancellationToken cancellationToken)
+        private IInternalConnection WaitForPooledConnection(CancellationToken cancellationToken, IInfoMessageEventNotifier eventNotifier)
         {
             Logger.Instance?.WriteLine($"{nameof(WaitForPooledConnection)} start");
             try
             {
                 var conn = _available.Take(cancellationToken);
                 Logger.Instance?.WriteLine($"{nameof(WaitForPooledConnection)} found connection");
+                conn.EventNotifier = eventNotifier;
                 return conn;
             }
             catch (OperationCanceledException)
@@ -182,7 +184,7 @@ namespace AdoNetCore.AseClient.Internal
             {
                 try
                 {
-                    AddToPool(await CreateNewPooledConnection(new CancellationToken()));
+                    AddToPool(await CreateNewPooledConnection(new CancellationToken(), null));
                     Logger.Instance?.WriteLine($"{nameof(TryFillPoolToMinSize)} added new internal connection");
                 }
                 catch(Exception ex)
@@ -201,7 +203,7 @@ namespace AdoNetCore.AseClient.Internal
             {
                 try
                 {
-                    AddToPool(await CreateNewPooledConnection(new CancellationToken()));
+                    AddToPool(await CreateNewPooledConnection(new CancellationToken(), null));
                     Logger.Instance?.WriteLine($"{nameof(TryReplaceConnection)} added new internal connection");
                 }
                 catch (Exception ex)

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -10,9 +10,9 @@ namespace AdoNetCore.AseClient.Internal
     {
         private static readonly ConcurrentDictionary<string, IConnectionPool> Pools = new ConcurrentDictionary<string, IConnectionPool>(StringComparer.OrdinalIgnoreCase);
 
-        public IInternalConnection Reserve(string connectionString, IConnectionParameters parameters)
+        public IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier)
         {
-            return Pools.GetOrAdd(connectionString, _ => new ConnectionPool(parameters, new InternalConnectionFactory(parameters))).Reserve();
+            return Pools.GetOrAdd(connectionString, _ => new ConnectionPool(parameters, new InternalConnectionFactory(parameters))).Reserve(eventNotifier);
         }
 
         public void Release(string connectionString, IInternalConnection connection)
@@ -22,6 +22,7 @@ namespace AdoNetCore.AseClient.Internal
                 return; //essentially, it's released :)
             }
 
+            connection.EventNotifier = null;
             if (Pools.TryGetValue(connectionString, out var pool))
             {
                 pool.Release(connection);

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -10,7 +10,7 @@ namespace AdoNetCore.AseClient.Internal
     {
         private static readonly ConcurrentDictionary<string, IConnectionPool> Pools = new ConcurrentDictionary<string, IConnectionPool>(StringComparer.OrdinalIgnoreCase);
 
-        public IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier)
+        public IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IEventNotifier eventNotifier)
         {
             return Pools.GetOrAdd(connectionString, _ => new ConnectionPool(parameters, new InternalConnectionFactory(parameters))).Reserve(eventNotifier);
         }

--- a/src/AdoNetCore.AseClient/Internal/EventNotifier.cs
+++ b/src/AdoNetCore.AseClient/Internal/EventNotifier.cs
@@ -1,0 +1,138 @@
+using System.Data;
+using AdoNetCore.AseClient.Interface;
+
+namespace AdoNetCore.AseClient.Internal
+{
+    internal class EventNotifier : IEventNotifier
+    {
+        private AseConnection _aseConnection;
+
+        internal EventNotifier(AseConnection aseConnection)
+        {
+            _aseConnection = aseConnection;
+        }
+
+        /// <summary>
+        /// Occurs when Adaptive Server ADO.NET Data Provider sends a warning or an informational message.
+        /// </summary>
+        /// <remarks>
+        /// The event handler receives an argument of type AseInfoMessageEventArgs containing data related to this event. 
+        /// The Errors and Message properties provide information specific to this event.
+        /// </remarks>
+        public event AseInfoMessageEventHandler InfoMessage
+        {
+            add => InfoMessageInternal += value;
+            remove => InfoMessageInternal -= value;
+        }
+
+        private event AseInfoMessageEventHandler InfoMessageInternal;
+
+        public void NotifyInfoMessage(AseErrorCollection errors, string message)
+        {
+            if (_aseConnection == null)
+                return;
+
+            var infoMessage = InfoMessageInternal;
+            infoMessage?.Invoke(_aseConnection, new AseInfoMessageEventArgs(errors, message));
+        }
+
+        /// <summary>
+        /// Occurs when the state of the connection changes.
+        /// </summary>
+        /// <remarks>
+        /// The event handler receives an argument of StateChangeEventArgs with data related to this event. Two StateChangeEventArgs properties 
+        /// provide information specific to this event: CurrentState and OriginalState.
+        /// </remarks>
+        public event StateChangeEventHandler StateChange
+        {
+            add => StateChangeInternal += value;
+            remove => StateChangeInternal -= value;
+        }
+
+        private event StateChangeEventHandler StateChangeInternal;
+
+        public void NotifyStateChange(ConnectionState originalState, ConnectionState currentState)
+        {
+            if (_aseConnection == null)
+                return;
+
+            var stateChange = StateChangeInternal;
+            stateChange?.Invoke(_aseConnection, new StateChangeEventArgs(originalState, currentState));
+        }
+
+        /// <summary>
+        /// Traces database activity within an application for debugging.
+        /// </summary>
+        /// <remarks>
+        /// <para>Use TraceEnter and TraceExit events to hook up your own tracing method. This event is unique to an 
+        /// instance of a connection. This allows different connections to be logged to different files. It can ignore 
+        /// the event, or you can program it for other tracing. In addition, by using a .NET event, you can set up more 
+        /// than one event handler for a single connection object. This enables you to log the event to both a window 
+        /// and a file at the same time.</para>
+        /// <para>Enable the ENABLETRACING connection property to trace Adaptive Server ADO.NET Data Provider activities. 
+        /// It is disabled by default to allow for better performance during normal execution where tracing is not needed. 
+        /// When this property is disabled, the TraceEnter and TraceExit events are not triggered, and tracing events are 
+        /// not executed. You can configure ENABLETRACING in the connection string using these values: True – triggers the 
+        /// TraceEnter and TraceExit events; and False – the default value; Adaptive Server ADO.NET Data Provider ignores 
+        /// the TraceEnter and TraceExit events.</para>
+        /// </remarks>
+        public event TraceEnterEventHandler TraceEnter
+        {
+            add => TraceEnterInternal += value;
+            remove => TraceEnterInternal -= value;
+        }
+
+        private event TraceEnterEventHandler TraceEnterInternal;
+
+        public void NotifyTraceEnter(object source, string method, params object[] parameters)
+        {
+            if (_aseConnection == null)
+                return;
+
+            var traceEnter = TraceEnterInternal;
+            traceEnter?.Invoke(_aseConnection, source, method, parameters);
+        }
+
+        /// <summary>
+        /// Traces database activity within an application for debugging.
+        /// </summary>
+        /// <remarks>
+        /// <para>Use TraceEnter and TraceExit events to hook up your own tracing method. This event is unique to an 
+        /// instance of a connection. This allows different connections to be logged to different files. It can ignore 
+        /// the event, or you can program it for other tracing. In addition, by using a .NET event, you can set up more 
+        /// than one event handler for a single connection object. This enables you to log the event to both a window 
+        /// and a file at the same time.</para>
+        /// <para>Enable the ENABLETRACING connection property to trace Adaptive Server ADO.NET Data Provider activities. 
+        /// It is disabled by default to allow for better performance during normal execution where tracing is not needed. 
+        /// When this property is disabled, the TraceEnter and TraceExit events are not triggered, and tracing events are 
+        /// not executed. You can configure ENABLETRACING in the connection string using these values: True – triggers the 
+        /// TraceEnter and TraceExit events; and False – the default value; Adaptive Server ADO.NET Data Provider ignores 
+        /// the TraceEnter and TraceExit events.</para>
+        /// </remarks>
+        public event TraceExitEventHandler TraceExit
+        {
+            add => TraceExitInternal += value;
+            remove => TraceExitInternal -= value;
+        }
+
+        private event TraceExitEventHandler TraceExitInternal;
+
+        public void NotifyTraceExit(object source, string method, object returnValue)
+        {
+            if (_aseConnection == null)
+                return;
+
+            var traceExit = TraceExitInternal;
+            traceExit?.Invoke(_aseConnection, source, method, returnValue);
+        }
+
+        public void ClearAll()
+        {
+            StateChangeInternal = null;
+            InfoMessageInternal = null;
+            TraceEnterInternal = null;
+            TraceExitInternal = null;
+            _aseConnection = null;
+        }
+    }
+}

--- a/src/AdoNetCore.AseClient/Internal/EventNotifier.cs
+++ b/src/AdoNetCore.AseClient/Internal/EventNotifier.cs
@@ -126,13 +126,41 @@ namespace AdoNetCore.AseClient.Internal
             traceExit?.Invoke(_aseConnection, source, method, returnValue);
         }
 
+        /// <summary>
+        /// Callback methods for new result sets and rows.
+        /// </summary>
+        public ResultSetCallbackHandler ResultSet { private get; set; }
+        public void NotifyResultSet()
+        {
+            if (_aseConnection == null)
+                return;
+
+            ResultSet?.Invoke();
+        }
+
+        public ResultRowCallbackHandler ResultRow { private get; set; }
+        public void NotifyResultRow(IAseDataCallbackReader reader)
+        {
+            if (_aseConnection == null)
+                return;
+
+            ResultRow?.Invoke(reader);
+        }
+
         public void ClearAll()
         {
             StateChangeInternal = null;
             InfoMessageInternal = null;
             TraceEnterInternal = null;
             TraceExitInternal = null;
+            ClearResultHandlers();
             _aseConnection = null;
+        }
+
+        public void ClearResultHandlers()
+        {
+            ResultSet = null;
+            ResultRow = null;
         }
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/Handler/DataReaderCallbackTokenHandler.cs
+++ b/src/AdoNetCore.AseClient/Internal/Handler/DataReaderCallbackTokenHandler.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using AdoNetCore.AseClient.Enum;
+using AdoNetCore.AseClient.Interface;
+using AdoNetCore.AseClient.Token;
+
+namespace AdoNetCore.AseClient.Internal.Handler
+{
+    internal class DataReaderCallbackTokenHandler : ITokenHandler
+    {
+        private static readonly HashSet<TokenType> AcceptedTypes = new HashSet<TokenType>
+        {
+            TokenType.TDS_ROWFMT2,
+            TokenType.TDS_ROWFMT,
+            TokenType.TDS_ROW
+        };
+
+        private readonly IResultsMessageEventNotifier _eventNotifier;
+        private readonly IList<TableResult> _results = new List<TableResult>();
+        private readonly AseDataReader _reader;
+        private int _numResults;
+
+        public DataReaderCallbackTokenHandler(AseCommand command, CommandBehavior behavior, IResultsMessageEventNotifier eventNotifier)
+        {
+            _eventNotifier = eventNotifier;
+            _reader = new AseDataReader(_results, command, behavior);
+            // Set up dummy result set in Reader so that processing in Handle is simpler
+            _results.Add(new TableResult());
+            _results[0].Rows.Add(null);
+            _reader.Read();
+        }
+
+        public bool CanHandle(TokenType type)
+        {
+            return AcceptedTypes.Contains(type);
+        }
+
+        public void Handle(IToken token)
+        {
+            // Only read the data into the first row of the first result set. We aren't allowing result set navigation for the callback.
+            switch (token)
+            {
+                case IFormatToken format:
+                    var current = new TableResult { Formats = format.Formats };
+                    current.Rows.Add(null);
+
+                    // Don't report the first result set
+                    if (_numResults++ > 0)
+                    {
+                        _eventNotifier?.NotifyResultSet();
+                    }
+
+                    _results[0] = current;
+                    break;
+                case RowToken row:
+                    _results[0].Rows[0] = new RowResult { Items = row.Values };
+                    _eventNotifier?.NotifyResultRow(_reader);
+                    break;
+            }
+        }
+    }
+}

--- a/src/AdoNetCore.AseClient/Internal/Handler/DoneTokenHandler.cs
+++ b/src/AdoNetCore.AseClient/Internal/Handler/DoneTokenHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Token;

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -122,7 +122,7 @@ namespace AdoNetCore.AseClient.Internal
                     new CapabilityToken()));
 
             var ackHandler = new LoginTokenHandler();
-            var messageHandler = new MessageTokenHandler();
+            var messageHandler = new MessageTokenHandler(EventNotifier);
 
             ReceiveTokens(
                 ackHandler,
@@ -191,7 +191,7 @@ namespace AdoNetCore.AseClient.Internal
                 CommandText = $"USE {databaseName}"
             }));
 
-            var messageHandler = new MessageTokenHandler();
+            var messageHandler = new MessageTokenHandler(EventNotifier);
 
             ReceiveTokens(
                 new EnvChangeTokenHandler(_environment),
@@ -215,7 +215,7 @@ namespace AdoNetCore.AseClient.Internal
                 SendPacket(new NormalPacket(BuildCommandTokens(command, behavior)));
 
                 var doneHandler = new DoneTokenHandler();
-                var messageHandler = new MessageTokenHandler();
+                var messageHandler = new MessageTokenHandler(EventNotifier);
                 var dataReaderHandler = readerSource != null ? new DataReaderTokenHandler() : null;
 
                 ReceiveTokens(
@@ -376,7 +376,7 @@ namespace AdoNetCore.AseClient.Internal
             SendPacket(new NormalPacket(OptionCommandToken.CreateSetTextSize(textSize)));
 
             var doneHandler = new DoneTokenHandler();
-            var messageHandler = new MessageTokenHandler();
+            var messageHandler = new MessageTokenHandler(EventNotifier);
             var dataReaderHandler = new DataReaderTokenHandler();
 
             ReceiveTokens(
@@ -547,5 +547,7 @@ SET FMTONLY OFF";
 
             return EmptyStatistics;
         }
+
+        public IInfoMessageEventNotifier EventNotifier { get; set; }
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.ExceptionServices;
@@ -18,12 +18,13 @@ namespace AdoNetCore.AseClient.Internal
             _parameters = parameters;
         }
 
-        public Task<IInternalConnection> GetNewConnection(CancellationToken token)
+        public Task<IInternalConnection> GetNewConnection(CancellationToken token, IInfoMessageEventNotifier eventNotifier)
         {
             Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(GetNewConnection)} start");
 
             var socket = CreateSocket(token);
             var connection = CreateConnection(socket, token); //will dispose socket on fail
+            connection.EventNotifier = eventNotifier;
 
             try
             {

--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.ExceptionServices;
@@ -18,7 +18,7 @@ namespace AdoNetCore.AseClient.Internal
             _parameters = parameters;
         }
 
-        public Task<IInternalConnection> GetNewConnection(CancellationToken token, IInfoMessageEventNotifier eventNotifier)
+        public Task<IInternalConnection> GetNewConnection(CancellationToken token, IEventNotifier eventNotifier)
         {
             Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(GetNewConnection)} start");
 

--- a/src/AdoNetCore.AseClient/Internal/ParameterValueExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/ParameterValueExtensions.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace AdoNetCore.AseClient.Internal
 {

--- a/src/AdoNetCore.AseClient/Internal/ReadablePartialStream.cs
+++ b/src/AdoNetCore.AseClient/Internal/ReadablePartialStream.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
 
 namespace AdoNetCore.AseClient.Internal
@@ -40,7 +39,7 @@ namespace AdoNetCore.AseClient.Internal
                 return bytesRead;
             }
 
-            throw new InvalidOperationException();
+            throw new EndOfStreamException();
         }
 
         public override int ReadByte()
@@ -51,7 +50,7 @@ namespace AdoNetCore.AseClient.Internal
                 return _inner.ReadByte();
             }
 
-            throw new InvalidOperationException();
+            throw new EndOfStreamException();
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/AdoNetCore.AseClient/Internal/StreamReadExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/StreamReadExtensions.cs
@@ -6,171 +6,201 @@ namespace AdoNetCore.AseClient.Internal
 {
     internal static class StreamReadExtensions
     {
-        public static bool ReadBool(this Stream stream)
+        public static bool ReadBool(this Stream stream, ref bool streamExceeded)
         {
-            return stream.ReadByte() != 0;
+            return stream.ReadByte(ref streamExceeded) != 0;
         }
 
-        public static short ReadShort(this Stream stream)
+        public static int ReadByte(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(1, ref streamExceeded) == false)
+                return -1;
+            return stream.ReadByte();
+        }
+
+        public static short ReadShort(this Stream stream, ref bool streamExceeded)
+        {
+            if (stream.CheckRequiredLength(2, ref streamExceeded) == false)
+                return 0;
             var buf = new byte[2];
             stream.Read(buf, 0, 2);
             return BitConverter.ToInt16(buf, 0);
         }
 
-        public static ushort ReadUShort(this Stream stream)
+        public static ushort ReadUShort(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(2, ref streamExceeded) == false)
+                return 0;
             var buf = new byte[2];
             stream.Read(buf, 0, 2);
             return BitConverter.ToUInt16(buf, 0);
         }
 
-        public static int ReadInt(this Stream stream)
+        public static int ReadInt(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(4, ref streamExceeded) == false)
+                return 0;
             var buf = new byte[4];
             stream.Read(buf, 0, 4);
             return BitConverter.ToInt32(buf, 0);
         }
 
-        public static uint ReadUInt(this Stream stream)
+        public static uint ReadUInt(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(4, ref streamExceeded) == false)
+                return 0;
             var buf = new byte[4];
             stream.Read(buf, 0, 4);
             return BitConverter.ToUInt32(buf, 0);
         }
 
-        public static long ReadLong(this Stream stream)
+        public static long ReadLong(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(8, ref streamExceeded) == false)
+                return 0L;
             var buf = new byte[8];
             stream.Read(buf, 0, 8);
             return BitConverter.ToInt64(buf, 0);
         }
 
-        public static ulong ReadULong(this Stream stream)
+        public static ulong ReadULong(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(8, ref streamExceeded) == false)
+                return 0;
             var buf = new byte[8];
             stream.Read(buf, 0, 8);
             return BitConverter.ToUInt64(buf, 0);
         }
 
-        public static float ReadFloat(this Stream stream)
+        public static float ReadFloat(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(4, ref streamExceeded) == false)
+                return 0.0f;
             var buf = new byte[4];
             stream.Read(buf, 0, 4);
             return BitConverter.ToSingle(buf, 0);
         }
 
-        public static double ReadDouble(this Stream stream)
+        public static double ReadDouble(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(8, ref streamExceeded) == false)
+                return 0.0;
             var buf = new byte[8];
             stream.Read(buf, 0, 8);
             return BitConverter.ToDouble(buf, 0);
         }
 
-        public static string ReadNullableByteLengthPrefixedString(this Stream stream, Encoding enc)
+        public static string ReadNullableByteLengthPrefixedString(this Stream stream, Encoding enc, ref bool streamExceeded)
         {
-            var length = stream.ReadByte();
-            if (length == 0)
+            var length = stream.ReadByte(ref streamExceeded);
+            if (length == 0 || streamExceeded)
             {
                 return null;
             }
 
-            return stream.ReadString(length, enc);
+            return stream.ReadString(length, enc, ref streamExceeded);
         }
 
-        public static string ReadNullableIntLengthPrefixedString(this Stream stream, Encoding enc)
+        public static string ReadNullableIntLengthPrefixedString(this Stream stream, Encoding enc, ref bool streamExceeded)
         {
-            var length = stream.ReadInt();
-            if (length == 0)
+            var length = stream.ReadInt(ref streamExceeded);
+            if (length == 0 || streamExceeded)
             {
                 return null;
             }
 
-            return stream.ReadString(length, enc);
+            return stream.ReadString(length, enc, ref streamExceeded);
         }
 
-        public static string ReadByteLengthPrefixedString(this Stream stream, Encoding enc)
+        public static string ReadByteLengthPrefixedString(this Stream stream, Encoding enc, ref bool streamExceeded)
         {
-            var length = stream.ReadByte();
-            return stream.ReadString(length, enc);
+            var length = stream.ReadByte(ref streamExceeded);
+            return stream.ReadString(length, enc, ref streamExceeded);
         }
 
-        public static string ReadShortLengthPrefixedString(this Stream stream, Encoding enc)
+        public static string ReadShortLengthPrefixedString(this Stream stream, Encoding enc, ref bool streamExceeded)
         {
-            var length = stream.ReadUShort();
-            return stream.ReadString(length, enc);
+            var length = stream.ReadUShort(ref streamExceeded);
+            return stream.ReadString(length, enc, ref streamExceeded);
         }
 
-        public static string ReadString(this Stream stream, int length, Encoding enc)
+        public static string ReadString(this Stream stream, int length, Encoding enc, ref bool streamExceeded)
         {
-            if (length == 0)
+            if (length == 0 || streamExceeded)
             {
                 return string.Empty;
             }
 
+            if (stream.CheckRequiredLength(length, ref streamExceeded) == false)
+                return null;
             var buf = new byte[length];
             stream.Read(buf, 0, length);
             return enc.GetString(buf);
         }
 
-        public static byte[] ReadByteLengthPrefixedByteArray(this Stream stream)
+        public static byte[] ReadByteLengthPrefixedByteArray(this Stream stream, ref bool streamExceeded)
         {
-            var length = stream.ReadByte();
+            var length = stream.ReadByte(ref streamExceeded);
 
-            if (length == 0)
+            if (length == 0 || streamExceeded)
             {
                 return new byte[0];
             }
 
-            return stream.ReadByteArray(length);
+            return stream.ReadByteArray(length, ref streamExceeded);
         }
 
-        public static byte[] ReadNullableByteLengthPrefixedByteArray(this Stream stream)
+        public static byte[] ReadNullableByteLengthPrefixedByteArray(this Stream stream, ref bool streamExceeded)
         {
-            var length = stream.ReadByte();
+            var length = stream.ReadByte(ref streamExceeded);
 
-            if (length == 0)
+            if (length == 0 || streamExceeded)
             {
                 return null;
             }
 
-            return stream.ReadByteArray(length);
+            return stream.ReadByteArray(length, ref streamExceeded);
         }
 
-        public static byte[] ReadNullableIntLengthPrefixedByteArray(this Stream stream)
+        public static byte[] ReadNullableIntLengthPrefixedByteArray(this Stream stream, ref bool streamExceeded)
         {
-            var length = stream.ReadInt();
+            var length = stream.ReadInt(ref streamExceeded);
 
-            if (length == 0)
+            if (length == 0 || streamExceeded)
             {
                 return null;
             }
 
-            return stream.ReadByteArray(length);
+            return stream.ReadByteArray(length, ref streamExceeded);
         }
 
-        public static byte[] ReadByteArray(this Stream stream, int length)
+        public static byte[] ReadByteArray(this Stream stream, int length, ref bool streamExceeded)
         {
-            if (length == 0)
+            if (length == 0 || streamExceeded)
             {
                 return new byte[0];
             }
 
+            if (stream.CheckRequiredLength(length, ref streamExceeded) == false)
+                return null;
             var buf = new byte[length];
             stream.Read(buf, 0, length);
             return buf;
         }
 
-        public static DateTime ReadIntPartDateTime(this Stream stream)
+        public static DateTime ReadIntPartDateTime(this Stream stream, ref bool streamExceeded)
         {
-            var days = stream.ReadInt();
-            var sqlTicks = stream.ReadInt();
+            var days = stream.ReadInt(ref streamExceeded);
+            var sqlTicks = stream.ReadInt(ref streamExceeded);
+
             return Constants.Sql.RegularDateTime.Epoch.AddDays(days).AddMilliseconds((int)(sqlTicks / Constants.Sql.RegularDateTime.TicksPerMillisecond));
         }
 
-        public static DateTime ReadBigDateTime(this Stream stream)
+        public static DateTime ReadBigDateTime(this Stream stream, ref bool streamExceeded)
         {
-            var usSinceYearZero = stream.ReadLong();
+            var usSinceYearZero = stream.ReadLong(ref streamExceeded);
+            if (streamExceeded)
+                return DateTime.MinValue;
             var usSinceEpoch = usSinceYearZero - Constants.Sql.BigDateTime.EpochMicroSeconds;
             var msSinceEpoch = usSinceEpoch / 1000;
             var timeSinceEpoch = TimeSpan.FromMilliseconds(msSinceEpoch);
@@ -178,28 +208,31 @@ namespace AdoNetCore.AseClient.Internal
             return Constants.Sql.BigDateTime.Epoch + timeSinceEpoch;
         }
 
-        public static DateTime ReadShortPartDateTime(this Stream stream)
+        public static DateTime ReadShortPartDateTime(this Stream stream, ref bool streamExceeded)
         {
-            var p1 = stream.ReadUShort();
-            var p2 = stream.ReadUShort();
+            var p1 = stream.ReadUShort(ref streamExceeded);
+            var p2 = stream.ReadUShort(ref streamExceeded);
 
             return Constants.Sql.RegularDateTime.Epoch.AddDays(p1).AddMinutes(p2);
         }
 
-        public static DateTime ReadDate(this Stream stream)
+        public static DateTime ReadDate(this Stream stream, ref bool streamExceeded)
         {
-            var p1 = stream.ReadInt();
+            var p1 = stream.ReadInt(ref streamExceeded);
             return Constants.Sql.RegularDateTime.Epoch.AddDays(p1);
         }
 
-        public static DateTime ReadTime(this Stream stream)
+        public static DateTime ReadTime(this Stream stream, ref bool streamExceeded)
         {
-            var sqlTicks = stream.ReadInt();
+            var sqlTicks = stream.ReadInt(ref streamExceeded);
             return Constants.Sql.RegularDateTime.Epoch.AddMilliseconds((int)(sqlTicks / Constants.Sql.RegularDateTime.TicksPerMillisecond));
         }
 
-        public static AseDecimal? ReadAseDecimal(this Stream stream, byte precision, byte scale)
+        public static AseDecimal? ReadAseDecimal(this Stream stream, byte precision, byte scale, ref bool streamExceeded)
         {
+            // We will read at least 2 bytes in this method so check it once and use the base ReadByte
+            if (stream.CheckRequiredLength(2, ref streamExceeded) == false)
+                return null;
             var length = stream.ReadByte();
             if (length == 0)
             {
@@ -209,6 +242,8 @@ namespace AdoNetCore.AseClient.Internal
             var remainingLength = length - 1;
             var buf = new byte[length];
 
+            if (stream.CheckRequiredLength(remainingLength, ref streamExceeded) == false)
+                return null;
             stream.Read(buf, 1, remainingLength);
             
             Array.Reverse(buf);
@@ -216,8 +251,10 @@ namespace AdoNetCore.AseClient.Internal
             return new AseDecimal(precision, scale, isPositive, buf);
         }
 
-        public static decimal ReadMoney(this Stream stream)
+        public static decimal ReadMoney(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(8, ref streamExceeded) == false)
+                return 0m;
             var buf = new byte[8];
             stream.Read(buf, 0, 8);
             buf = new[]
@@ -228,11 +265,20 @@ namespace AdoNetCore.AseClient.Internal
             return new decimal(BitConverter.ToInt64(buf, 0)) / 10000m;
         }
 
-        public static decimal ReadSmallMoney(this Stream stream)
+        public static decimal ReadSmallMoney(this Stream stream, ref bool streamExceeded)
         {
+            if (stream.CheckRequiredLength(4, ref streamExceeded) == false)
+                return 0m;
             var buf = new byte[4];
             stream.Read(buf, 0, 4);
             return new decimal(BitConverter.ToInt32(buf, 0)) / 10000m;
+        }
+
+        public static bool CheckRequiredLength(this Stream stream, long length, ref bool streamExceeded)
+        {
+            if (length < 0 || stream.Position + length > stream.Length)
+                streamExceeded = true;
+            return !streamExceeded;
         }
     }
 }

--- a/src/AdoNetCore.AseClient/Packet/AttentionPacket.cs
+++ b/src/AdoNetCore.AseClient/Packet/AttentionPacket.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Text;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Internal;

--- a/src/AdoNetCore.AseClient/Packet/NormalPacket.cs
+++ b/src/AdoNetCore.AseClient/Packet/NormalPacket.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Internal;

--- a/src/AdoNetCore.AseClient/Token/CapabilityToken.cs
+++ b/src/AdoNetCore.AseClient/Token/CapabilityToken.cs
@@ -18,10 +18,16 @@ namespace AdoNetCore.AseClient.Token
             stream.Write(_capabilityBytes);
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
-            var remainingLength = stream.ReadUShort();
+            var remainingLength = stream.ReadUShort(ref streamExceeded);
+            if (streamExceeded)
+                return;
             var capabilityBytes = new byte[remainingLength];
+            //if (stream.Position > stream.Length - remainingLength)
+            //    throw new InvalidOperationException();
+            if (stream.CheckRequiredLength(remainingLength, ref streamExceeded) == false)
+                return;
             stream.Read(capabilityBytes, 0, remainingLength);
         }
 
@@ -65,10 +71,10 @@ CAPABILITY Token (0xE2); variable length.
 0x00 (00000000): (DATA_NOBIT), (DATA_NOINT4), (DATA_NOINT2), (DATA_NOINT1), (RES_NOPARAM), (RES_NOEED), (RES_NOMSG), (NONE) 
          */
 
-        public static CapabilityToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static CapabilityToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new CapabilityToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/DbRpcToken.cs
+++ b/src/AdoNetCore.AseClient/Token/DbRpcToken.cs
@@ -39,7 +39,7 @@ namespace AdoNetCore.AseClient.Token
                 : DbRpcOptions.TDS_RPC_UNUSED));
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             throw new NotImplementedException();
         }

--- a/src/AdoNetCore.AseClient/Token/DoneInProcToken.cs
+++ b/src/AdoNetCore.AseClient/Token/DoneInProcToken.cs
@@ -8,10 +8,10 @@ namespace AdoNetCore.AseClient.Token
     internal class DoneInProcToken : DoneProcCommonToken, IToken
     {
         public TokenType Type => TokenType.TDS_DONEINPROC;
-        public static DoneInProcToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static DoneInProcToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new DoneInProcToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/DoneProcCommonToken.cs
+++ b/src/AdoNetCore.AseClient/Token/DoneProcCommonToken.cs
@@ -47,11 +47,11 @@ namespace AdoNetCore.AseClient.Token
             throw new NotImplementedException();
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
-            Status = (DoneProcStatus)stream.ReadUShort();
-            TransactionState = (TranState)stream.ReadUShort();
-            Count = stream.ReadInt();
+            Status = (DoneProcStatus)stream.ReadUShort(ref streamExceeded);
+            TransactionState = (TranState)stream.ReadUShort(ref streamExceeded);
+            Count = stream.ReadInt(ref streamExceeded);
             Logger.Instance?.WriteLine($"<- {Status}, {TransactionState}, {Count}");
         }
     }

--- a/src/AdoNetCore.AseClient/Token/DoneProcToken.cs
+++ b/src/AdoNetCore.AseClient/Token/DoneProcToken.cs
@@ -9,10 +9,10 @@ namespace AdoNetCore.AseClient.Token
     {
         public TokenType Type => TokenType.TDS_DONEPROC;
 
-        public static DoneProcToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static DoneProcToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new DoneProcToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/DoneToken.cs
+++ b/src/AdoNetCore.AseClient/Token/DoneToken.cs
@@ -64,18 +64,18 @@ namespace AdoNetCore.AseClient.Token
             throw new NotImplementedException();
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
-            Status = (DoneStatus) stream.ReadUShort();
-            TransactionState = (TranState) stream.ReadUShort();
-            Count = stream.ReadInt();
+            Status = (DoneStatus) stream.ReadUShort(ref streamExceeded);
+            TransactionState = (TranState) stream.ReadUShort(ref streamExceeded);
+            Count = stream.ReadInt(ref streamExceeded);
             Logger.Instance?.WriteLine($"<- {Type}: {Status} ({Count})");
         }
 
-        public static DoneToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static DoneToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new DoneToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/EedToken.cs
+++ b/src/AdoNetCore.AseClient/Token/EedToken.cs
@@ -36,31 +36,33 @@ namespace AdoNetCore.AseClient.Token
             throw new NotImplementedException();
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
-            var remainingLength = stream.ReadUShort();
+            var remainingLength = stream.ReadUShort(ref streamExceeded);
+            if (stream.CheckRequiredLength(remainingLength, ref streamExceeded) == false)
+                return;
 
             using (var ts = new ReadablePartialStream(stream, remainingLength))
             {
-                MessageNumber = ts.ReadInt();
-                State = ts.ReadByte();
+                MessageNumber = ts.ReadInt(ref streamExceeded);
+                State = ts.ReadByte();                  // Already checked remainingLength so can use non-checking version
                 Severity = ts.ReadByte();
                 var sqlStateLen = ts.ReadByte();
                 SqlState = new byte[sqlStateLen];
                 ts.Read(SqlState, 0, sqlStateLen);
                 Status = (EedStatus)ts.ReadByte();
-                TransactionStatus = (TranState)ts.ReadUShort();
-                Message = ts.ReadShortLengthPrefixedString(env.Encoding);
-                ServerName = ts.ReadByteLengthPrefixedString(env.Encoding);
-                ProcedureName = ts.ReadByteLengthPrefixedString(env.Encoding);
-                LineNumber = ts.ReadUShort();
+                TransactionStatus = (TranState)ts.ReadUShort(ref streamExceeded);
+                Message = ts.ReadShortLengthPrefixedString(env.Encoding, ref streamExceeded);
+                ServerName = ts.ReadByteLengthPrefixedString(env.Encoding, ref streamExceeded);
+                ProcedureName = ts.ReadByteLengthPrefixedString(env.Encoding, ref streamExceeded);
+                LineNumber = ts.ReadUShort(ref streamExceeded);
             }
         }
 
-        public static EedToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static EedToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new EedToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/LanguageToken.cs
+++ b/src/AdoNetCore.AseClient/Token/LanguageToken.cs
@@ -22,12 +22,14 @@ namespace AdoNetCore.AseClient.Token
             stream.Write(commandText, 0, commandText.Length);
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
-            var remainingLength = stream.ReadInt();
+            var remainingLength = stream.ReadInt(ref streamExceeded);
+            if (stream.CheckRequiredLength(remainingLength, ref streamExceeded) == false)
+                return;
             var status = stream.ReadByte();
             HasParameters = (status & 1) > 0;
-            CommandText = stream.ReadString(remainingLength - 1, env.Encoding);
+            CommandText = stream.ReadString(remainingLength - 1, env.Encoding, ref streamExceeded);
         }
     }
 }

--- a/src/AdoNetCore.AseClient/Token/OptionCommandToken.cs
+++ b/src/AdoNetCore.AseClient/Token/OptionCommandToken.cs
@@ -32,21 +32,23 @@ namespace AdoNetCore.AseClient.Token
             stream.WriteBytePrefixedByteArray(Arguments);
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previousFormatToken)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previousFormatToken, ref bool streamExceeded)
         {
-            var remainingLength = stream.ReadShort();
+            var remainingLength = stream.ReadShort(ref streamExceeded);
+            if (stream.CheckRequiredLength(remainingLength, ref streamExceeded) == false)
+                return;
             using (var ts = new ReadablePartialStream(stream, remainingLength))
             {
                 Command = (CommandType)ts.ReadByte();
                 Option = (OptionType)ts.ReadByte();
-                Arguments = ts.ReadByteLengthPrefixedByteArray();
+                Arguments = ts.ReadByteLengthPrefixedByteArray(ref streamExceeded);
             }
         }
 
-        public static OptionCommandToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static OptionCommandToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new OptionCommandToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
 

--- a/src/AdoNetCore.AseClient/Token/ParameterFormat2Token.cs
+++ b/src/AdoNetCore.AseClient/Token/ParameterFormat2Token.cs
@@ -9,10 +9,10 @@ namespace AdoNetCore.AseClient.Token
     {
         public ParameterFormat2Token() : base(TokenType.TDS_PARAMFMT2) { }
 
-        public static ParameterFormat2Token Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static ParameterFormat2Token Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new ParameterFormat2Token();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/ParameterFormatToken.cs
+++ b/src/AdoNetCore.AseClient/Token/ParameterFormatToken.cs
@@ -9,10 +9,10 @@ namespace AdoNetCore.AseClient.Token
     {
         public ParameterFormatToken() : base(TokenType.TDS_PARAMFMT) { }
 
-        public static ParameterFormatToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static ParameterFormatToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new ParameterFormatToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/ParametersToken.cs
+++ b/src/AdoNetCore.AseClient/Token/ParametersToken.cs
@@ -31,7 +31,7 @@ namespace AdoNetCore.AseClient.Token
             }
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var parameters = new List<Parameter>();
             foreach(var format in previous.Formats)
@@ -39,18 +39,20 @@ namespace AdoNetCore.AseClient.Token
                 var p = new Parameter
                 {
                     Format = format,
-                    Value = ValueReader.Read(stream, format, env)
+                    Value = ValueReader.Read(stream, format, env, ref streamExceeded)
                 };
+                if (streamExceeded)
+                    return;
                 parameters.Add(p);
             }
             Parameters = parameters.ToArray();
             Logger.Instance?.WriteLine($"<- {Type}: {Parameters.Length} parameters");
         }
 
-        public static ParametersToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static ParametersToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new ParametersToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/ReturnStatusToken.cs
+++ b/src/AdoNetCore.AseClient/Token/ReturnStatusToken.cs
@@ -17,16 +17,16 @@ namespace AdoNetCore.AseClient.Token
             stream.WriteInt(Status);
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previous)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
-            Status = stream.ReadInt();
+            Status = stream.ReadInt(ref streamExceeded);
             Logger.Instance?.WriteLine($"<- {Type}: {Status}");
         }
 
-        public static ReturnStatusToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static ReturnStatusToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new ReturnStatusToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/src/AdoNetCore.AseClient/Token/RowToken.cs
+++ b/src/AdoNetCore.AseClient/Token/RowToken.cs
@@ -20,21 +20,23 @@ namespace AdoNetCore.AseClient.Token
             throw new NotImplementedException();
         }
 
-        public void Read(Stream stream, DbEnvironment env, IFormatToken previousFormatToken)
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previousFormatToken, ref bool streamExceeded)
         {
             Logger.Instance?.WriteLine($"<- {Type}");
             var values = new List<object>();
             foreach (var format in previousFormatToken.Formats)
             {
-                values.Add(ValueReader.Read(stream, format, env));
+                values.Add(ValueReader.Read(stream, format, env, ref streamExceeded));
+                if (streamExceeded)
+                    return;
             }
             Values = values.ToArray();
         }
 
-        public static RowToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        public static RowToken Create(Stream stream, DbEnvironment env, IFormatToken previous, ref bool streamExceeded)
         {
             var t = new RowToken();
-            t.Read(stream, env, previous);
+            t.Read(stream, env, previous, ref streamExceeded);
             return t;
         }
     }

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Internal;
@@ -162,7 +162,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>()))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), null))
                 .Returns(mockConnection.Object);
 
             mockConnection.Setup(x => x.ChangeDatabase(It.IsAny<string>()));
@@ -184,7 +184,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>()))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), null))
                 .Returns(mockConnection.Object);
 
             mockConnection.Setup(x => x.ChangeDatabase(It.IsAny<string>()));
@@ -267,7 +267,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>()))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), null))
                 .Returns(mockConnection.Object);
 
             return mockConnectionPoolManager.Object;

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -162,7 +162,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), null))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IEventNotifier>()))
                 .Returns(mockConnection.Object);
 
             mockConnection.Setup(x => x.ChangeDatabase(It.IsAny<string>()));
@@ -184,7 +184,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), null))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IEventNotifier>()))
                 .Returns(mockConnection.Object);
 
             mockConnection.Setup(x => x.ChangeDatabase(It.IsAny<string>()));
@@ -267,7 +267,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), null))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IEventNotifier>()))
                 .Returns(mockConnection.Object);
 
             return mockConnectionPoolManager.Object;

--- a/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
@@ -154,7 +154,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
 
         private class ImmediateConnectionFactory : IInternalConnectionFactory
         {
-            public async Task<IInternalConnection> GetNewConnection(CancellationToken token, IInfoMessageEventNotifier eventNotifier)
+            public async Task<IInternalConnection> GetNewConnection(CancellationToken token, IEventNotifier eventNotifier)
             {
                 return await Task.FromResult<IInternalConnection>(new DoNothingInternalConnection());
             }
@@ -190,6 +190,11 @@ namespace AdoNetCore.AseClient.Tests.Unit
                 return null;
             }
 
+            public void ExecuteCallbackReader(CommandBehavior behavior, AseCommand command, AseTransaction transaction,
+                ResultRowCallbackHandler resultRowHandler, ResultSetCallbackHandler resultSetHandler = null)
+            {
+            }
+
             public Task<DbDataReader> ExecuteReaderTaskRunnable(CommandBehavior behavior, AseCommand command, AseTransaction transaction)
             {
                 return Task.FromResult<DbDataReader>(null);
@@ -214,12 +219,12 @@ namespace AdoNetCore.AseClient.Tests.Unit
             {
                 return new Dictionary<string, long>();
             }
-            public IInfoMessageEventNotifier EventNotifier { get; set; }
+            public IEventNotifier EventNotifier { get; set; }
         }
 
         private class SlowConnectionFactory : IInternalConnectionFactory
         {
-            public Task<IInternalConnection> GetNewConnection(CancellationToken token, IInfoMessageEventNotifier eventNotifier)
+            public Task<IInternalConnection> GetNewConnection(CancellationToken token, IEventNotifier eventNotifier)
             {
                 token.WaitHandle.WaitOne();
                 throw new TimeoutException($"Timed out attempting to create new connection");


### PR DESCRIPTION
Useful when calling a long-running stored procedure that will return multiple result sets, e.g. batch processing. Retrieve each result set as soon as they are sent to the client as opposed to the .NET way which is to buffer up all results (and the return code) before allowing access to the first result. NOTE: Using this new feature means you will be getting the result sets _before_ the return code is available!