### PR TITLE
Fix CatchAllToken length calculation

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/TokenParser.cs
+++ b/src/AdoNetCore.AseClient/Internal/TokenParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using AdoNetCore.AseClient.Enum;
@@ -19,7 +19,8 @@ namespace AdoNetCore.AseClient.Internal
             IFormatToken previousFormatToken = null;
             while (stream.Position < stream.Length)
             {
-                var tokenType = (TokenType)stream.ReadByte();
+                var rawTokenType = (byte) stream.ReadByte();
+                var tokenType = (TokenType)rawTokenType;
 
                 if (Readers.ContainsKey(tokenType))
                 {
@@ -36,7 +37,7 @@ namespace AdoNetCore.AseClient.Internal
                 else
                 {
                     Logger.Instance?.WriteLine($"!!! Hit unknown token type {tokenType} !!!");
-                    var t = new CatchAllToken(tokenType);
+                    var t = new CatchAllToken(rawTokenType);
                     t.Read(stream, env, previousFormatToken);
                     yield return t;
                 }

--- a/test/AdoNetCore.AseClient.Tests/Unit/CatchAllTokenTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/CatchAllTokenTests.cs
@@ -1,0 +1,116 @@
+using System.IO;
+using AdoNetCore.AseClient.Internal;
+using AdoNetCore.AseClient.Token;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Unit
+{
+    [TestFixture]
+    [Category("quick")]
+    public class CatchAllTokenTests
+    {
+        [TestCase("110xxxxx", 0b1100_0000)]
+        [TestCase("110xxxxx", 0b1101_1111)]
+        public void ZeroLengthToken_NoBytesRead(string _, byte type)
+        {
+            var t = new CatchAllToken(type);
+            using (var ms = new MemoryStream())
+            {
+                t.Read(ms, new DbEnvironment(), null);
+
+                Assert.AreEqual(0, ms.Position);
+            }
+        }
+
+        [TestCase("xx1100xx - 0s", 0b0011_0000, 1)]
+        [TestCase("xx1100xx - 1s", 0b1111_0011, 1)]
+        [TestCase("xx1101xx - 0s", 0b0011_0100, 2)]
+        [TestCase("xx1101xx - 1s", 0b1111_0111, 2)]
+        [TestCase("xx1110xx - 0s", 0b0011_1000, 4)]
+        [TestCase("xx1110xx - 1s", 0b1111_1011, 4)]
+        [TestCase("xx1111xx - 0s", 0b0011_1100, 8)]
+        [TestCase("xx1111xx - 1s", 0b1111_1111, 8)]
+        public void FixedLengthToken_FixedBytesRead(string _, byte type, int dataLength)
+        {
+            var t = new CatchAllToken(type);
+            using (var ms = new MemoryStream())
+            {
+                ms.Write(new byte[dataLength]);
+                ms.Seek(0, SeekOrigin.Begin);
+
+                t.Read(ms, new DbEnvironment(), null);
+
+                Assert.AreEqual(ms.Length, ms.Position);
+            }
+        }
+
+        [TestCase("1010xxxx - 0s", 0b1010_0000)]
+        [TestCase("1010xxxx - 1s", 0b1010_1111)]
+        [TestCase("1110xxxx - 0s", 0b1110_0000)]
+        [TestCase("1110xxxx - 1s", 0b1110_1111)]
+        [TestCase("1000xxxx - 0s", 0b1000_0000)]
+        [TestCase("1000xxxx - 1s", 0b1000_1111)]
+        public void VariableLengthToken_UShortLength_VariableBytesRead(string _, byte type)
+        {
+            ushort dataLength = 10;
+
+            var t = new CatchAllToken(type);
+            using (var ms = new MemoryStream())
+            {
+                ms.WriteUShort(dataLength);
+                ms.Write(new byte[dataLength]);
+                ms.Seek(0, SeekOrigin.Begin);
+
+                t.Read(ms, new DbEnvironment(), null);
+
+                Assert.AreEqual(ms.Length, ms.Position);
+            }
+        }
+
+        [TestCase("001000xx - 0s", 0b0010_0000)]
+        [TestCase("001000xx - 1s", 0b0010_0011)]
+        [TestCase("011000xx - 0s", 0b0110_0000)]
+        [TestCase("011000xx - 1s", 0b0110_0011)]
+        public void VariableLengthToken_UIntLength_VariableBytesRead(string _, byte type)
+        {
+            uint dataLength = 10;
+
+            var t = new CatchAllToken(type);
+            using (var ms = new MemoryStream())
+            {
+                ms.WriteUInt(dataLength);
+                ms.Write(new byte[dataLength]);
+                ms.Seek(0, SeekOrigin.Begin);
+
+                t.Read(ms, new DbEnvironment(), null);
+
+                Assert.AreEqual(ms.Length, ms.Position);
+            }
+        }
+
+        [TestCase("001001xx - 0s", 0b0010_0100)]
+        [TestCase("001001xx - 1s", 0b0010_0111)]
+        [TestCase("001010xx - 0s", 0b0010_1000)]
+        [TestCase("001010xx - 1s", 0b0010_1011)]
+        [TestCase("011001xx - 0s", 0b0110_0100)]
+        [TestCase("011001xx - 1s", 0b0110_0111)]
+        [TestCase("011010xx - 0s", 0b0110_1000)]
+        [TestCase("011010xx - 1s", 0b0110_1011)]
+        public void VariableLengthToken_ByteLength_VariableBytesRead(string _, byte type)
+        {
+            byte dataLength = 10;
+
+            var t = new CatchAllToken(type);
+            using (var ms = new MemoryStream())
+            {
+                ms.WriteByte(dataLength);
+                ms.Write(new byte[dataLength]);
+                ms.Seek(0, SeekOrigin.Begin);
+
+                t.Read(ms, new DbEnvironment(), null);
+
+                Assert.AreEqual(ms.Length, ms.Position);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #107 

As per the spec, the token type encodes information about the token's length (or how to read it).

There are some exceptions to this rule, but I don't think we need to handle these cases:

* `TDS_ROW` and `TDS_PARAM`
  * We can already parse these tokens
* `TDS_ALTROW`
  * Relates to "compute" operations -- would require parsing/understanding of the `TDS_ALTFMT` token type as well.
* `TDS_KEY`
  * The client sends this token to the server during "cursor" operations

