### PR TITLE
Implemented the EnableServerPacketSize connection string property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ In all of the test cases the `AdoNetCore.AseClient` performed better or equivale
 | `Database` or `Db` or `Initial Catalog`                                                    | &#10003;
 | `Data Source` or `DataSource` or `Address` or `Addr` or `Network Address` or `Server Name` | &#10003;
 | `DSURL` or `Directory Service URL`                                                         | &#10003; | Multiple URLs are not supported; network drivers other than NLWNSCK (TCP/IP socket) are not supported; LDAP is not supported
-| `EnableServerPacketSize`                                                                   | TODO | May not be supported any more by capability bits
+| `EnableServerPacketSize`                                                                   | &#10003;
 | `Encryption`                                                                               | TODO | Refer to issue [#98](https://github.com/DataAction/AdoNetCore.AseClient/issues/98)
 | `EncryptPassword`                                                                          | &#10003; | Values 0 (disabled) and 1 (enabled) are supported. The highest encryption standard of the ASE 15.x and 16x servers is implemented.
 | `LoginTimeOut` or `Connect Timeout` or `Connection Timeout`                                | &#10003; | For pooled connections this translates to the time it takes to reserve a connection from the pool
@@ -143,7 +143,7 @@ In all of the test cases the `AdoNetCore.AseClient` performed better or equivale
 | `Pooling`                                                                                  | &#10003;
 | `Port` or `Server Port`                                                                    | &#10003;
 | `Pwd` or `Password`                                                                        | &#10003;
-| `RestrictMaximum PacketSize`                                                               | TODO | May not be supported any more by capability bits
+| `RestrictMaximum PacketSize`                                                               | &#10003;
 | `TextSize`                                                                                 | &#10003;
 | `TrustedFile`                                                                              | TODO | Refer to issue [#98](https://github.com/DataAction/AdoNetCore.AseClient/issues/98)
 | `Uid` or `UserID` or `User ID` or `User`                                                   | &#10003;

--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ In all of the test cases the `AdoNetCore.AseClient` performed better or equivale
 | `Pooling`                                                                                  | &#10003;
 | `Port` or `Server Port`                                                                    | &#10003;
 | `Pwd` or `Password`                                                                        | &#10003;
-| `RestrictMaximum PacketSize`                                                               | &#10003;
 | `TextSize`                                                                                 | &#10003;
 | `TrustedFile`                                                                              | TODO | Refer to issue [#98](https://github.com/DataAction/AdoNetCore.AseClient/issues/98)
 | `Uid` or `UserID` or `User ID` or `User`                                                   | &#10003;

--- a/src/AdoNetCore.AseClient/Interface/IConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionParameters.cs
@@ -24,5 +24,6 @@ namespace AdoNetCore.AseClient.Interface
         bool UseAseDecimal { get; }
         bool EncryptPassword { get; }
         bool AnsiNull { get; }
+        bool EnableServerPacketSize { get; }
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
@@ -58,6 +58,7 @@ namespace AdoNetCore.AseClient.Internal
             {"UseAseDecimal", ParseUseAseDecimal},
             {"EncryptPassword", ParseEncryptPassword},
             {"AnsiNull", ParseAnsiNull},
+            {"EnableServerPacketSize", ParseEnableServerPacketSize},
         };
 
         public static ConnectionParameters Parse(string connectionString)
@@ -271,6 +272,19 @@ namespace AdoNetCore.AseClient.Internal
             result.AnsiNull = Convert.ToInt32(item.PropertyValue) == 1;
         }
 
+        private static void ParseEnableServerPacketSize(ConnectionStringItem item, ConnectionParameters result)
+        {
+            if (int.TryParse(item.PropertyValue?.Trim(), out var intValue))
+            {
+                result.EnableServerPacketSize = intValue != 0;
+            }
+            else if (bool.TryParse(item.PropertyValue?.Trim(), out var boolValue))
+            {
+                result.EnableServerPacketSize = boolValue;
+            }
+        }
+        
+
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static void ValidateConnectionParameters(ConnectionParameters result)
         {
@@ -348,5 +362,6 @@ namespace AdoNetCore.AseClient.Internal
 
         public bool EncryptPassword { get; private set; }
         public bool AnsiNull { get; private set; }
+        public bool EnableServerPacketSize { get; private set; } = true;
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
@@ -283,7 +283,6 @@ namespace AdoNetCore.AseClient.Internal
                 result.EnableServerPacketSize = boolValue;
             }
         }
-        
 
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static void ValidateConnectionParameters(ConnectionParameters result)

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -124,7 +124,7 @@ namespace AdoNetCore.AseClient.Internal
                     _parameters.Charset,
                     "ADO.NET",
                     _environment.PacketSize,
-                    new CapabilityToken(),
+                    new CapabilityToken(_parameters.EnableServerPacketSize),
                     _parameters.EncryptPassword));
 
             var ackHandler = new LoginTokenHandler();

--- a/src/AdoNetCore.AseClient/Token/CapabilityToken.cs
+++ b/src/AdoNetCore.AseClient/Token/CapabilityToken.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Internal;
@@ -9,6 +9,14 @@ namespace AdoNetCore.AseClient.Token
     {
         //todo: create fields to represent capabilities
         public TokenType Type => TokenType.TDS_CAPABILITY;
+
+        public CapabilityToken(bool enableServerPacketSize = true)
+        {
+            if (!enableServerPacketSize)
+            {
+                _capabilityBytes[6] &= 0b_0111_1111; // Clear the most significant bit - REQ_SRVPKTSIZE.
+            }
+        }
 
         public void Write(Stream stream, DbEnvironment env)
         {

--- a/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
+++ b/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
@@ -23,6 +23,7 @@ namespace AdoNetCore.AseClient.Tests
         public static string NonPooledUnique => $"{NonPooled}; UniqueID={{{Guid.NewGuid()}}}";
         public static string PooledUnique => $"{Pooled}; UniqueID={{{Guid.NewGuid()}}}";
         public static string BadPass => $"Data Source={Server}; Port={Port}; Uid={User}; Pwd=XXXXXXXX; db={Database};";
+        public static string EnableServerPacketSize => $"{Prefix}; EnableServerPacketSize=0;";
 
         public static string AnsiNullOn => $"{Prefix}; AnsiNull=1";
         public static string AnsiNullOff => $"{Prefix}; AnsiNull=0";

--- a/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
@@ -104,5 +104,17 @@ namespace AdoNetCore.AseClient.Tests.Integration
             yield return new TestCaseData(100, 1000, ConnectionStrings.Pooled100);
             yield return new TestCaseData(100, 10000, ConnectionStrings.Pooled100);
         }
+
+        [Test]
+        public void Login_EnableServerPacketSizeDisabled_Success()
+        {
+            using (var connection = GetConnection(ConnectionStrings.EnableServerPacketSize))
+            {
+                if (typeof(T) == typeof(CoreFxConnectionProvider))
+                {
+                    connection.Open();
+                }
+            }
+        }
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
@@ -252,6 +252,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             public bool UseAseDecimal { get; } = false;
             public bool EncryptPassword { get; } = false;
             public bool AnsiNull { get; } = false;
+            public bool EnableServerPacketSize { get; } = true;
         }
     }
 }


### PR DESCRIPTION
Fixes #125.

Have removed the connection string doco for `RestrictMaximumPacketSize` because it doesn't appear to actually be supported anywhere in the TDS spec. It isn't supported by the [JConnect driver](http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc39001.0605/html/prjdbc/prjdbc14.htm) either, even though that one does support `ENABLE_SERVER_ PACKETSIZE`.