### PR TITLE
Named parameters false

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ In all of the test cases the `AdoNetCore.AseClient` performed better or equivale
 | `LoginTimeOut` or `Connect Timeout` or `Connection Timeout`                                | &#10003; | For pooled connections this translates to the time it takes to reserve a connection from the pool
 | `Max Pool Size`                                                                            | &#10003;
 | `Min Pool Size`                                                                            | &#10003; | <ul><li>The pool will attempt to prime itself on creation up to this size (in a thread)</li><li>When a connection is killed, the pool will attempt to replace it if the pool size is less than Min</li></ul>
+| `NamedParameters`                                                                          | &#10003;
 | `PacketSize` or `Packet Size`                        |                                      &#10003; | The server can decide to change this value
 | `Ping Server`                                                                              | &#10003;
 | `Pooling`                                                                                  | &#10003;

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Data.Common;
 using System.IO;
@@ -26,6 +26,7 @@ namespace AdoNetCore.AseClient
         private int _commandTimeout = DefaultCommandTimeout;
         private string _commandText;
         private UpdateRowSource _updatedRowSource;
+        private bool? _namedParameters;
 
         /// <summary>
         /// Constructor function for an <see cref="AseCommand"/> instance.
@@ -34,7 +35,6 @@ namespace AdoNetCore.AseClient
         public AseCommand()
         {
             AseParameters = new AseParameterCollection();
-            NamedParameters = true;
         }
 
         /// <summary>
@@ -45,7 +45,6 @@ namespace AdoNetCore.AseClient
         public AseCommand(string commandText)
         {
             AseParameters = new AseParameterCollection();
-            NamedParameters = true;
 
             CommandText = commandText;
         }
@@ -61,7 +60,6 @@ namespace AdoNetCore.AseClient
             _transaction = connection.Transaction;
 
             AseParameters = new AseParameterCollection();
-            NamedParameters = connection.NamedParameters;
 
             CommandText = commandText;
         }
@@ -78,7 +76,6 @@ namespace AdoNetCore.AseClient
             _transaction = transaction;
 
             AseParameters = new AseParameterCollection();
-            NamedParameters = connection.NamedParameters;
 
             CommandText = commandText;
         }
@@ -89,7 +86,6 @@ namespace AdoNetCore.AseClient
             _transaction = connection.Transaction;
 
             AseParameters = new AseParameterCollection();
-            NamedParameters = connection.NamedParameters;
         }
 
         /// <summary>
@@ -345,7 +341,6 @@ namespace AdoNetCore.AseClient
                 }
 
                 _connection = value;
-                NamedParameters = _connection?.NamedParameters ?? false;
             }
         }
 
@@ -391,7 +386,23 @@ namespace AdoNetCore.AseClient
         /// <remarks>
         /// When true then the ? syntax is not supported, and a name is expected.
         /// </remarks>
-        public bool NamedParameters { get; set; } // TODO - implement
+        public bool NamedParameters
+        {
+            get
+            {
+                if(_namedParameters.HasValue)
+                {
+                    return _namedParameters.Value;
+                }
+                if(_connection != null)
+                {
+                    return _connection.NamedParameters;
+                }
+
+                return true;
+            }
+            set => _namedParameters = value;
+        }
 
         /// <summary>
         /// Gets the <see cref="AseParameterCollection" /> used by this instance of the AseCommand. 

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -518,7 +518,6 @@ namespace AdoNetCore.AseClient
         {
             get
             {
-
                 if(_namedParameters.HasValue)
                 {
                     return _namedParameters.Value;

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -24,6 +24,7 @@ namespace AdoNetCore.AseClient
         private bool _isDisposed;
         private AseTransaction _transaction;
         private readonly IEventNotifier _eventNotifier;
+        private bool? _namedParameters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AseConnection" /> class.
@@ -113,7 +114,6 @@ namespace AdoNetCore.AseClient
             ConnectionString = connectionString;
             InternalConnectionTimeout = 15; // Default to 15s as per the SAP AseClient http://infocenter.sybase.com/help/topic/com.sybase.infocenter.dc20066.1570100/doc/html/san1364409555258.html
             _connectionPoolManager = connectionPoolManager;
-            NamedParameters = true;
             _isDisposed = false;
             _eventNotifier = new EventNotifier(this);
         }
@@ -234,7 +234,7 @@ namespace AdoNetCore.AseClient
                 throw new ObjectDisposedException(nameof(AseConnection));
             }
 
-            var aseCommand = new AseCommand(this) { NamedParameters = NamedParameters };
+            var aseCommand = new AseCommand(this);
 
             return aseCommand;
         }
@@ -514,10 +514,23 @@ namespace AdoNetCore.AseClient
         /// <remarks>
         /// This can be either set by the ConnectionString (NamedParameters='true'/'false') or the user can set it directly through an instance of AseConnection.
         /// </remarks>
-        public bool NamedParameters // TODO - implement
+        public bool NamedParameters
         {
-            get;
-            set;
+            get
+            {
+
+                if(_namedParameters.HasValue)
+                {
+                    return _namedParameters.Value;
+                }
+                if(_internal != null)
+                {
+                    return _internal.NamedParameters;
+                }
+
+                return true;
+            }
+            set => _namedParameters = value;
         }
 
 #if ENABLE_CLONEABLE_INTERFACE

--- a/src/AdoNetCore.AseClient/Interface/IConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionParameters.cs
@@ -25,5 +25,6 @@ namespace AdoNetCore.AseClient.Interface
         bool EncryptPassword { get; }
         bool AnsiNull { get; }
         bool EnableServerPacketSize { get; }
+        bool NamedParameters { get; }
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -91,6 +91,18 @@ namespace AdoNetCore.AseClient.Interface
         void SetAnsiNull(bool enabled);
 
         /// <summary>
+        /// Governs the default behavior of the AseCommand objects associated with this connection.
+        /// </summary>
+        /// <remarks>
+        /// This can be either set by the ConnectionString (NamedParameters='true'/'false') or the user can set it directly through an instance of AseConnection.
+        /// </remarks>
+        bool NamedParameters
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Indicates if this connection is doomed to destruction
         /// </summary>
         bool IsDoomed { get; set; }

--- a/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
@@ -59,6 +59,7 @@ namespace AdoNetCore.AseClient.Internal
             {"EncryptPassword", ParseEncryptPassword},
             {"AnsiNull", ParseAnsiNull},
             {"EnableServerPacketSize", ParseEnableServerPacketSize},
+            {"NamedParameters", ParseNamedParameters},
         };
 
         public static ConnectionParameters Parse(string connectionString)
@@ -284,6 +285,19 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
+
+        private static void ParseNamedParameters(ConnectionStringItem item, ConnectionParameters result)
+        {
+            if (int.TryParse(item.PropertyValue?.Trim(), out var intValue))
+            {
+                result.NamedParameters = intValue != 0;
+            }
+            else if (bool.TryParse(item.PropertyValue?.Trim(), out var boolValue))
+            {
+                result.NamedParameters = boolValue;
+            }
+        }
+
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static void ValidateConnectionParameters(ConnectionParameters result)
         {
@@ -362,5 +376,7 @@ namespace AdoNetCore.AseClient.Internal
         public bool EncryptPassword { get; private set; }
         public bool AnsiNull { get; private set; }
         public bool EnableServerPacketSize { get; private set; } = true;
+
+        public bool NamedParameters { get; private set; } = true;
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
@@ -285,7 +285,6 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
-
         private static void ParseNamedParameters(ConnectionStringItem item, ConnectionParameters result)
         {
             if (int.TryParse(item.PropertyValue?.Trim(), out var intValue))

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
@@ -66,6 +66,7 @@ namespace AdoNetCore.AseClient.Internal
 
                     connection.ChangeDatabase(_parameters.Database);
                     connection.SetTextSize(_parameters.TextSize);
+                    connection.NamedParameters = _parameters.NamedParameters;
 
                     if (_parameters.AnsiNull)
                     {

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -488,6 +488,12 @@ namespace AdoNetCore.AseClient.Internal
             messageHandler.AssertNoErrors();
         }
 
+        public bool NamedParameters
+        {
+            get;
+            set;
+        }
+
         private bool _isDoomed;
         public bool IsDoomed
         {
@@ -601,7 +607,7 @@ SET FMTONLY OFF";
         }
 
         public static readonly IDictionary EmptyStatistics = new ReadOnlyDictionary<string, long>(new Dictionary<string, long>());
-        
+
         public bool StatisticsEnabled
         {
             get => _statisticsEnabled;

--- a/src/AdoNetCore.AseClient/Internal/NamedParametersExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/NamedParametersExtensions.cs
@@ -1,0 +1,46 @@
+using System.Text.RegularExpressions;
+
+namespace AdoNetCore.AseClient.Internal
+{
+    internal static class NamedParametersExtensions
+    {
+        private const string Placeholder = "3f256325-c423-49bb-a3ce-7911c5531d95";
+
+        private static readonly Regex SingleQuoteRegex = new Regex(
+            $@"(?<='[^']*)({Placeholder})(?=[^']*')",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex SquareBracketRegex = new Regex(
+            $@"(?<=\[[^]]*)({Placeholder})(?=[^]]*\])",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex DoubleQuoteRegex = new Regex(
+            $@"(?<=""[^""]*)({Placeholder})(?=[^""]*"")",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex QuestionMarkParameterRegex = new Regex(
+            $"({Placeholder})",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        public static string ToNamedParameters(this string query)
+        {
+            // Step 1 - replace all '?' with placeholder.
+            query = query.Replace("?", Placeholder);
+
+            // Step 2 - replace instances of the placeholder between square brackets with the original question mark.
+            query = SquareBracketRegex.Replace(query, "?");
+
+            // Step 3 - replace instances of the placeholder between double quotes with the original question mark.
+            query = DoubleQuoteRegex.Replace(query, "?");
+
+            // Step 4 - replace instances of the placeholder between double quotes with the original question mark.
+            query = SingleQuoteRegex.Replace(query, "?");
+
+            // Step 5 - replace instances of the placeholder with parameters.
+            var i = 0;
+            string Evaluator(Match match) => $"@p{i++}";
+            
+            return QuestionMarkParameterRegex.Replace(query, Evaluator);
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
+++ b/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
@@ -26,6 +26,7 @@ namespace AdoNetCore.AseClient.Tests
         public static string EnableServerPacketSize => $"{Prefix}; EnableServerPacketSize=0;";
 
         public static string AnsiNullOn => $"{Prefix}; AnsiNull=1";
+        public static string NamedParametersOff => $"{Prefix}; NamedParameters=false";
         public static string AnsiNullOff => $"{Prefix}; AnsiNull=0";
 
         private static IDictionary<string, string> _loginDetails;

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -1,0 +1,152 @@
+using System.Data;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration
+{
+    [TestFixture]
+    public class NamedParamsTests
+    {
+        [Test]
+        public void ExecuteProcedure_WithNamedParametersFalse_ReturnsParameterValues()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.NamedParametersOff))
+            {
+                connection.Open();
+
+                Assert.IsFalse(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsFalse(command.NamedParameters);
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"IF OBJECT_ID('EchoParameter') IS NOT NULL 
+BEGIN 
+    DROP PROCEDURE EchoParameter
+END";
+                    command.ExecuteNonQuery();
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"CREATE PROCEDURE [EchoParameter]
+(
+    @parameter1 VARCHAR(256),
+    @parameter2 VARCHAR(256)
+)
+AS 
+BEGIN 
+    SELECT @parameter1 + ' ' + @parameter2 AS Value
+END";
+                    command.ExecuteNonQuery();
+
+
+                    command.CommandType = CommandType.StoredProcedure;
+                    command.AseParameters.Add(0, "General Kenobi?");
+                    command.AseParameters.Add(1, "Hello there!");
+                    command.CommandText = "EchoParameter";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("General Kenobi? Hello there!", result);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteProcedure_WithNamedParametersTrue_ReturnsParameterValue()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Default))
+            {
+                connection.Open();
+
+                Assert.IsTrue(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsTrue(command.NamedParameters);
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"IF OBJECT_ID('EchoParameter') IS NOT NULL 
+BEGIN 
+    DROP PROCEDURE EchoParameter
+END";
+                    command.ExecuteNonQuery();
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"CREATE PROCEDURE [EchoParameter]
+(
+    @parameter1 VARCHAR(256),
+    @parameter2 VARCHAR(256)
+)
+AS 
+BEGIN 
+    SELECT @parameter1 + ' ' + @parameter2 AS Value
+END";
+                    command.ExecuteNonQuery();
+
+
+                    command.CommandType = CommandType.StoredProcedure;
+                    command.AseParameters.Add("@parameter1", "General Kenobi?");
+                    command.AseParameters.Add("@parameter2", "Hello there!");
+                    command.CommandText = "EchoParameter";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("General Kenobi? Hello there!", result);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteQuery_WithNamedParametersFalse_ReturnsParameterValues()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.NamedParametersOff))
+            {
+                connection.Open();
+
+                Assert.IsFalse(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsFalse(command.NamedParameters);
+                    
+                    command.CommandType = CommandType.Text;
+                    command.AseParameters.Add(0, "General Kenobi?");
+                    command.AseParameters.Add(1, "Hello there!");
+                    command.CommandText = "SELECT ? + ' ' + ? AS Value";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("General Kenobi? Hello there!", result);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteQuery_WithNamedParametersFalse_ReturnsParameterValues2()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.NamedParametersOff))
+            {
+                connection.Open();
+
+                Assert.IsFalse(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsFalse(command.NamedParameters);
+                    
+                    command.CommandType = CommandType.Text;
+                    command.AseParameters.Add(0, "syscolumns");
+                    command.CommandText = "SELECT TOP 1 Name FROM sysobjects WHERE Name = ?";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("syscolumns", result);
+                }
+            }
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Text.RegularExpressions;
 using AdoNetCore.AseClient.Internal;
 using NUnit.Framework;
 

--- a/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
@@ -175,6 +175,8 @@ namespace AdoNetCore.AseClient.Tests.Unit
             public string Database { get; }
             public string DataSource { get; }
             public string ServerVersion { get; }
+            public bool NamedParameters { get; set; }
+
             public int ExecuteNonQuery(AseCommand command, AseTransaction transaction)
             {
                 return 0;
@@ -253,6 +255,8 @@ namespace AdoNetCore.AseClient.Tests.Unit
             public bool EncryptPassword { get; } = false;
             public bool AnsiNull { get; } = false;
             public bool EnableServerPacketSize { get; } = true;
+
+            public bool NamedParameters { get; } = true;
         }
     }
 }


### PR DESCRIPTION
Fixes #129 .

Approach is the same as the reference driver - to rewrite the query with generated @p0, @p1 ... @pn parameters if `NamedParameters=false`, and a question mark is matched.

All tests pass.