### PR TITLE
Prevent a possible IndexOutOfRangeException

### DIFF
--- a/src/AdoNetCore.AseClient/AseDataReader.cs
+++ b/src/AdoNetCore.AseClient/AseDataReader.cs
@@ -658,7 +658,7 @@ namespace AdoNetCore.AseClient
         /// <returns>true if the reader is pointing at a row of data; false otherwise.</returns>
         public override bool Read()
         {
-            if (_currentResult < 0)
+            if (_currentResult < 0 || _currentResult >= _results.Length)
             {
                 return false;
             }


### PR DESCRIPTION
Fixes #102 

I think what is happening is that the caller is calling `reader.NextResult()` which returns false as it is pointing past the last item in the result set. The caller should stop at this point, but must not be checking the return value. Then it calls `reader.Read()` which throws. 

From the stack trace reported, it's the only way I can see that this could happen.

I've made `reader.Read()` more robust.