### PR TITLE
Named parameters false single regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ In all of the test cases the `AdoNetCore.AseClient` performed better or equivale
 | `LoginTimeOut` or `Connect Timeout` or `Connection Timeout`                                | &#10003; | For pooled connections this translates to the time it takes to reserve a connection from the pool
 | `Max Pool Size`                                                                            | &#10003;
 | `Min Pool Size`                                                                            | &#10003; | <ul><li>The pool will attempt to prime itself on creation up to this size (in a thread)</li><li>When a connection is killed, the pool will attempt to replace it if the pool size is less than Min</li></ul>
+| `NamedParameters`                                                                          | &#10003;
 | `PacketSize` or `Packet Size`                        |                                      &#10003; | The server can decide to change this value
 | `Ping Server`                                                                              | &#10003;
 | `Pooling`                                                                                  | &#10003;

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data;
 using System.Data.Common;
 using System.IO;
@@ -26,6 +26,7 @@ namespace AdoNetCore.AseClient
         private int _commandTimeout = DefaultCommandTimeout;
         private string _commandText;
         private UpdateRowSource _updatedRowSource;
+        private bool? _namedParameters;
 
         /// <summary>
         /// Constructor function for an <see cref="AseCommand"/> instance.
@@ -34,7 +35,6 @@ namespace AdoNetCore.AseClient
         public AseCommand()
         {
             AseParameters = new AseParameterCollection();
-            NamedParameters = true;
         }
 
         /// <summary>
@@ -45,7 +45,6 @@ namespace AdoNetCore.AseClient
         public AseCommand(string commandText)
         {
             AseParameters = new AseParameterCollection();
-            NamedParameters = true;
 
             CommandText = commandText;
         }
@@ -61,7 +60,6 @@ namespace AdoNetCore.AseClient
             _transaction = connection.Transaction;
 
             AseParameters = new AseParameterCollection();
-            NamedParameters = connection.NamedParameters;
 
             CommandText = commandText;
         }
@@ -78,7 +76,6 @@ namespace AdoNetCore.AseClient
             _transaction = transaction;
 
             AseParameters = new AseParameterCollection();
-            NamedParameters = connection.NamedParameters;
 
             CommandText = commandText;
         }
@@ -89,7 +86,6 @@ namespace AdoNetCore.AseClient
             _transaction = connection.Transaction;
 
             AseParameters = new AseParameterCollection();
-            NamedParameters = connection.NamedParameters;
         }
 
         /// <summary>
@@ -345,7 +341,6 @@ namespace AdoNetCore.AseClient
                 }
 
                 _connection = value;
-                NamedParameters = _connection?.NamedParameters ?? false;
             }
         }
 
@@ -391,7 +386,23 @@ namespace AdoNetCore.AseClient
         /// <remarks>
         /// When true then the ? syntax is not supported, and a name is expected.
         /// </remarks>
-        public bool NamedParameters { get; set; } // TODO - implement
+        public bool NamedParameters
+        {
+            get
+            {
+                if(_namedParameters.HasValue)
+                {
+                    return _namedParameters.Value;
+                }
+                if(_connection != null)
+                {
+                    return _connection.NamedParameters;
+                }
+
+                return true;
+            }
+            set => _namedParameters = value;
+        }
 
         /// <summary>
         /// Gets the <see cref="AseParameterCollection" /> used by this instance of the AseCommand. 

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -518,7 +518,6 @@ namespace AdoNetCore.AseClient
         {
             get
             {
-
                 if(_namedParameters.HasValue)
                 {
                     return _namedParameters.Value;

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -24,6 +24,7 @@ namespace AdoNetCore.AseClient
         private bool _isDisposed;
         private AseTransaction _transaction;
         private readonly IEventNotifier _eventNotifier;
+        private bool? _namedParameters;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AseConnection" /> class.
@@ -113,7 +114,6 @@ namespace AdoNetCore.AseClient
             ConnectionString = connectionString;
             InternalConnectionTimeout = 15; // Default to 15s as per the SAP AseClient http://infocenter.sybase.com/help/topic/com.sybase.infocenter.dc20066.1570100/doc/html/san1364409555258.html
             _connectionPoolManager = connectionPoolManager;
-            NamedParameters = true;
             _isDisposed = false;
             _eventNotifier = new EventNotifier(this);
         }
@@ -234,7 +234,7 @@ namespace AdoNetCore.AseClient
                 throw new ObjectDisposedException(nameof(AseConnection));
             }
 
-            var aseCommand = new AseCommand(this) { NamedParameters = NamedParameters };
+            var aseCommand = new AseCommand(this);
 
             return aseCommand;
         }
@@ -514,10 +514,23 @@ namespace AdoNetCore.AseClient
         /// <remarks>
         /// This can be either set by the ConnectionString (NamedParameters='true'/'false') or the user can set it directly through an instance of AseConnection.
         /// </remarks>
-        public bool NamedParameters // TODO - implement
+        public bool NamedParameters
         {
-            get;
-            set;
+            get
+            {
+
+                if(_namedParameters.HasValue)
+                {
+                    return _namedParameters.Value;
+                }
+                if(_internal != null)
+                {
+                    return _internal.NamedParameters;
+                }
+
+                return true;
+            }
+            set => _namedParameters = value;
         }
 
 #if ENABLE_CLONEABLE_INTERFACE

--- a/src/AdoNetCore.AseClient/Interface/IConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionParameters.cs
@@ -25,5 +25,6 @@ namespace AdoNetCore.AseClient.Interface
         bool EncryptPassword { get; }
         bool AnsiNull { get; }
         bool EnableServerPacketSize { get; }
+        bool NamedParameters { get; }
     }
 }

--- a/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Interface/IInternalConnection.cs
@@ -91,6 +91,18 @@ namespace AdoNetCore.AseClient.Interface
         void SetAnsiNull(bool enabled);
 
         /// <summary>
+        /// Governs the default behavior of the AseCommand objects associated with this connection.
+        /// </summary>
+        /// <remarks>
+        /// This can be either set by the ConnectionString (NamedParameters='true'/'false') or the user can set it directly through an instance of AseConnection.
+        /// </remarks>
+        bool NamedParameters
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Indicates if this connection is doomed to destruction
         /// </summary>
         bool IsDoomed { get; set; }

--- a/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
@@ -59,6 +59,7 @@ namespace AdoNetCore.AseClient.Internal
             {"EncryptPassword", ParseEncryptPassword},
             {"AnsiNull", ParseAnsiNull},
             {"EnableServerPacketSize", ParseEnableServerPacketSize},
+            {"NamedParameters", ParseNamedParameters},
         };
 
         public static ConnectionParameters Parse(string connectionString)
@@ -284,6 +285,19 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
+
+        private static void ParseNamedParameters(ConnectionStringItem item, ConnectionParameters result)
+        {
+            if (int.TryParse(item.PropertyValue?.Trim(), out var intValue))
+            {
+                result.NamedParameters = intValue != 0;
+            }
+            else if (bool.TryParse(item.PropertyValue?.Trim(), out var boolValue))
+            {
+                result.NamedParameters = boolValue;
+            }
+        }
+
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static void ValidateConnectionParameters(ConnectionParameters result)
         {
@@ -362,5 +376,7 @@ namespace AdoNetCore.AseClient.Internal
         public bool EncryptPassword { get; private set; }
         public bool AnsiNull { get; private set; }
         public bool EnableServerPacketSize { get; private set; } = true;
+
+        public bool NamedParameters { get; private set; } = true;
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionParameters.cs
@@ -285,7 +285,6 @@ namespace AdoNetCore.AseClient.Internal
             }
         }
 
-
         private static void ParseNamedParameters(ConnectionStringItem item, ConnectionParameters result)
         {
             if (int.TryParse(item.PropertyValue?.Trim(), out var intValue))

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPool.cs
@@ -66,6 +66,7 @@ namespace AdoNetCore.AseClient.Internal
 
                     connection.ChangeDatabase(_parameters.Database);
                     connection.SetTextSize(_parameters.TextSize);
+                    connection.NamedParameters = _parameters.NamedParameters;
 
                     if (_parameters.AnsiNull)
                     {

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -488,6 +488,12 @@ namespace AdoNetCore.AseClient.Internal
             messageHandler.AssertNoErrors();
         }
 
+        public bool NamedParameters
+        {
+            get;
+            set;
+        }
+
         private bool _isDoomed;
         public bool IsDoomed
         {
@@ -601,7 +607,7 @@ SET FMTONLY OFF";
         }
 
         public static readonly IDictionary EmptyStatistics = new ReadOnlyDictionary<string, long>(new Dictionary<string, long>());
-        
+
         public bool StatisticsEnabled
         {
             get => _statisticsEnabled;

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -551,7 +551,14 @@ namespace AdoNetCore.AseClient.Internal
 
             if (!namedParameters)
             {
-                result = result.ToNamedParameters();
+                try
+                {
+                    result = result.ToNamedParameters();
+                }
+                catch (ArgumentException)
+                {
+                    throw new AseException("Incorrect syntax. Possible mismatched quotes on string literal, or identifier delimiter.");
+                }
             }
 
             if ((behavior & CommandBehavior.SchemaOnly) == CommandBehavior.SchemaOnly)

--- a/src/AdoNetCore.AseClient/Internal/NamedParametersExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/NamedParametersExtensions.cs
@@ -1,46 +1,84 @@
+using System;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace AdoNetCore.AseClient.Internal
 {
     internal static class NamedParametersExtensions
     {
-        private const string Placeholder = "3f256325-c423-49bb-a3ce-7911c5531d95";
+        // All patterns are intended to be joined into a single regexp pattern
+        // As such, they are all intended to be mutually exclusive
+        // i.e. starting at any index i, no two patterns should find a match starting at the same position j
 
-        private static readonly Regex SingleQuoteRegex = new Regex(
-            $@"(?<='[^']*)({Placeholder})(?=[^']*')",
-            RegexOptions.Compiled | RegexOptions.Multiline);
+        // SQL quoted string 'strings with '' escaping'
+        internal const string AnsiString = "'(?:[^']|'')*'";
 
-        private static readonly Regex SquareBracketRegex = new Regex(
-            $@"(?<=\[[^]]*)({Placeholder})(?=[^]]*\])",
-            RegexOptions.Compiled | RegexOptions.Multiline);
+        // SQL quoted identifier "id with "" escaping"
+        internal const string AnsiQuotedIdentifier = "\"(?:[^\"]|\"\")*\"";
 
-        private static readonly Regex DoubleQuoteRegex = new Regex(
-            $@"(?<=""[^""]*)({Placeholder})(?=[^""]*"")",
-            RegexOptions.Compiled | RegexOptions.Multiline);
+        // SQL square quoted identifier [id with ]] escaping]
+        internal const string SquareQuotedIdentifier = @"\[(?:[^\]]|\]\])*]";
 
-        private static readonly Regex QuestionMarkParameterRegex = new Regex(
-            $"({Placeholder})",
-            RegexOptions.Compiled | RegexOptions.Multiline);
+        // SQL inline comments --
+        internal const string AnsiLineComment = @"--[^\n]*(?:\n|$)";
+
+        // C style comments, both inline // and block /* */ 
+        internal const string CComment = @"/(?:/[^\n]*(?:\n|$)|\*.*?\*/)";
+
+        // Simple sequence of characters that aren't part of comments, strings,
+        // quoted identifiers, or the question marks we are trying to separate
+        // NOTE: negative lookahead used to consume / and - when they aren't forming a comment
+        // They can be removed, but would require merging all the individual patterns and impact testability and maintainability
+        internal const string SimpleSqlPart = "(?:[^'\"[/?-]|/(?![/*])|-(?!-))+";
+
+        // Final two patterns: one to tokenise sql strings,
+        // and the final to merge the tokenised input and collect positional parameters ?
+
+        // A single non-question-mark piece of sql.
+        // It could be any of a quoted identifier, string, comment, or character sequence
+        internal const string SqlPart = AnsiString
+            + "|" + AnsiQuotedIdentifier
+            + "|" + SquareQuotedIdentifier
+            + "|" + AnsiLineComment
+            + "|" + CComment
+            + "|" + SimpleSqlPart;
+
+        // Matches on a single question mark, or a sequence of sql parts (merged into one string)
+        internal static readonly Regex QuestionableSql = new Regex(
+            "(?:" + SqlPart + ")+|\\?", RegexOptions.Compiled | RegexOptions.Singleline
+        );
 
         public static string ToNamedParameters(this string query)
         {
-            // Step 1 - replace all '?' with placeholder.
-            query = query.Replace("?", Placeholder);
+            // Break apart the query, replace all parameters (isolated as single ? strings),
+            // and rejoin them all to reform the string using named parameters
 
-            // Step 2 - replace instances of the placeholder between square brackets with the original question mark.
-            query = SquareBracketRegex.Replace(query, "?");
+            var matches = QuestionableSql.Matches(query);
+            var replacedSql = new StringBuilder();
+            int sqlLength = 0;
+            int paramIndex = 0;
+            foreach (Match m in matches)
+            {
+                string val = m.Value;
+                sqlLength += val.Length;
+                if (val == "?")
+                {
+                    replacedSql.Append("@p").Append(paramIndex);
+                    paramIndex++;
+                }
+                else
+                {
+                    replacedSql.Append(val);
+                }
+            }
 
-            // Step 3 - replace instances of the placeholder between double quotes with the original question mark.
-            query = DoubleQuoteRegex.Replace(query, "?");
-
-            // Step 4 - replace instances of the placeholder between double quotes with the original question mark.
-            query = SingleQuoteRegex.Replace(query, "?");
-
-            // Step 5 - replace instances of the placeholder with parameters.
-            var i = 0;
-            string Evaluator(Match match) => $"@p{i++}";
-            
-            return QuestionMarkParameterRegex.Replace(query, Evaluator);
+            // Verify query was separated correctly
+            // This should only trigger on unbalanced inputs, eg "select 'abc from foo"
+            if (sqlLength != query.Length)
+            {
+                throw new ArgumentException($"Input query did not split cleanly: {query}");
+            }
+            return replacedSql.ToString();
         }
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/NamedParametersExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/NamedParametersExtensions.cs
@@ -1,0 +1,46 @@
+using System.Text.RegularExpressions;
+
+namespace AdoNetCore.AseClient.Internal
+{
+    internal static class NamedParametersExtensions
+    {
+        private const string Placeholder = "3f256325-c423-49bb-a3ce-7911c5531d95";
+
+        private static readonly Regex SingleQuoteRegex = new Regex(
+            $@"(?<='[^']*)({Placeholder})(?=[^']*')",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex SquareBracketRegex = new Regex(
+            $@"(?<=\[[^]]*)({Placeholder})(?=[^]]*\])",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex DoubleQuoteRegex = new Regex(
+            $@"(?<=""[^""]*)({Placeholder})(?=[^""]*"")",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex QuestionMarkParameterRegex = new Regex(
+            $"({Placeholder})",
+            RegexOptions.Compiled | RegexOptions.Multiline);
+
+        public static string ToNamedParameters(this string query)
+        {
+            // Step 1 - replace all '?' with placeholder.
+            query = query.Replace("?", Placeholder);
+
+            // Step 2 - replace instances of the placeholder between square brackets with the original question mark.
+            query = SquareBracketRegex.Replace(query, "?");
+
+            // Step 3 - replace instances of the placeholder between double quotes with the original question mark.
+            query = DoubleQuoteRegex.Replace(query, "?");
+
+            // Step 4 - replace instances of the placeholder between double quotes with the original question mark.
+            query = SingleQuoteRegex.Replace(query, "?");
+
+            // Step 5 - replace instances of the placeholder with parameters.
+            var i = 0;
+            string Evaluator(Match match) => $"@p{i++}";
+            
+            return QuestionMarkParameterRegex.Replace(query, Evaluator);
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
+++ b/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
@@ -26,6 +26,7 @@ namespace AdoNetCore.AseClient.Tests
         public static string EnableServerPacketSize => $"{Prefix}; EnableServerPacketSize=0;";
 
         public static string AnsiNullOn => $"{Prefix}; AnsiNull=1";
+        public static string NamedParametersOff => $"{Prefix}; NamedParameters=false";
         public static string AnsiNullOff => $"{Prefix}; AnsiNull=0";
 
         private static IDictionary<string, string> _loginDetails;

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -1,0 +1,152 @@
+using System.Data;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration
+{
+    [TestFixture]
+    public class NamedParamsTests
+    {
+        [Test]
+        public void ExecuteProcedure_WithNamedParametersFalse_ReturnsParameterValues()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.NamedParametersOff))
+            {
+                connection.Open();
+
+                Assert.IsFalse(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsFalse(command.NamedParameters);
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"IF OBJECT_ID('EchoParameter') IS NOT NULL 
+BEGIN 
+    DROP PROCEDURE EchoParameter
+END";
+                    command.ExecuteNonQuery();
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"CREATE PROCEDURE [EchoParameter]
+(
+    @parameter1 VARCHAR(256),
+    @parameter2 VARCHAR(256)
+)
+AS 
+BEGIN 
+    SELECT @parameter1 + ' ' + @parameter2 AS Value
+END";
+                    command.ExecuteNonQuery();
+
+
+                    command.CommandType = CommandType.StoredProcedure;
+                    command.AseParameters.Add(0, "General Kenobi?");
+                    command.AseParameters.Add(1, "Hello there!");
+                    command.CommandText = "EchoParameter";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("General Kenobi? Hello there!", result);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteProcedure_WithNamedParametersTrue_ReturnsParameterValue()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Default))
+            {
+                connection.Open();
+
+                Assert.IsTrue(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsTrue(command.NamedParameters);
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"IF OBJECT_ID('EchoParameter') IS NOT NULL 
+BEGIN 
+    DROP PROCEDURE EchoParameter
+END";
+                    command.ExecuteNonQuery();
+
+                    command.CommandType = CommandType.Text;
+                    command.CommandText =
+                        @"CREATE PROCEDURE [EchoParameter]
+(
+    @parameter1 VARCHAR(256),
+    @parameter2 VARCHAR(256)
+)
+AS 
+BEGIN 
+    SELECT @parameter1 + ' ' + @parameter2 AS Value
+END";
+                    command.ExecuteNonQuery();
+
+
+                    command.CommandType = CommandType.StoredProcedure;
+                    command.AseParameters.Add("@parameter1", "General Kenobi?");
+                    command.AseParameters.Add("@parameter2", "Hello there!");
+                    command.CommandText = "EchoParameter";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("General Kenobi? Hello there!", result);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteQuery_WithNamedParametersFalse_ReturnsParameterValues()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.NamedParametersOff))
+            {
+                connection.Open();
+
+                Assert.IsFalse(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsFalse(command.NamedParameters);
+                    
+                    command.CommandType = CommandType.Text;
+                    command.AseParameters.Add(0, "General Kenobi?");
+                    command.AseParameters.Add(1, "Hello there!");
+                    command.CommandText = "SELECT ? + ' ' + ? AS Value";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("General Kenobi? Hello there!", result);
+                }
+            }
+        }
+
+        [Test]
+        public void ExecuteQuery_WithNamedParametersFalse_ReturnsParameterValues2()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.NamedParametersOff))
+            {
+                connection.Open();
+
+                Assert.IsFalse(connection.NamedParameters);
+
+                using (var command = connection.CreateCommand())
+                {
+                    Assert.IsFalse(command.NamedParameters);
+                    
+                    command.CommandType = CommandType.Text;
+                    command.AseParameters.Add(0, "syscolumns");
+                    command.CommandText = "SELECT TOP 1 Name FROM sysobjects WHERE Name = ?";
+
+                    var result = command.ExecuteScalar();
+
+                    Assert.AreEqual("syscolumns", result);
+                }
+            }
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -188,6 +188,54 @@ END";
         [TestCase("SELECT 1, 'What is going on \"arggh?\"', \"What is going on ?\" FROM myTable WHERE myColumn = ?", "SELECT 1, 'What is going on \"arggh?\"', \"What is going on ?\" FROM myTable WHERE myColumn = @p0")]
         [TestCase("EXEC myProc ?,?,?,?", "EXEC myProc @p0,@p1,@p2,@p3")]
         [TestCase("EXEC myProc ?, ?, ?, ?", "EXEC myProc @p0, @p1, @p2, @p3")]
+        [TestCase("select 'abcdef', ?, 'ghijki', ? from foo", "select 'abcdef', @p0, 'ghijki', @p1 from foo")]
+        [TestCase("select 'abc\"def', ?, 'ghi\"jki', ? from foo", "select 'abc\"def', @p0, 'ghi\"jki', @p1 from foo")]
+        [TestCase("select 'abc''def', ?, 'ghi''jki', ? from foo", "select 'abc''def', @p0, 'ghi''jki', @p1 from foo")]
+        [TestCase("select 'abc[def', ?, 'ghi]jki', ? from foo", "select 'abc[def', @p0, 'ghi]jki', @p1 from foo")]
+        [TestCase("select 'abc--def', ?, 'ghi--jki', ? from foo", "select 'abc--def', @p0, 'ghi--jki', @p1 from foo")]
+        [TestCase("select 'abc//def', ?, 'ghi//jki', ? from foo", "select 'abc//def', @p0, 'ghi//jki', @p1 from foo")]
+        [TestCase("select 'abc/*def', ?, 'ghi*/jki', ? from foo", "select 'abc/*def', @p0, 'ghi*/jki', @p1 from foo")]
+        [TestCase("select \"abcdef\", ?, \"ghijki\", ? from foo", "select \"abcdef\", @p0, \"ghijki\", @p1 from foo")]
+        [TestCase("select \"abc[def\", ?, \"ghi]jki\", ? from foo", "select \"abc[def\", @p0, \"ghi]jki\", @p1 from foo")]
+        [TestCase("select \"abc\"\"def\", ?, \"ghi\"\"jki\", ? from foo", "select \"abc\"\"def\", @p0, \"ghi\"\"jki\", @p1 from foo")]
+        [TestCase("select \"abc'def\", ?, \"ghi'jki\", ? from foo", "select \"abc'def\", @p0, \"ghi'jki\", @p1 from foo")]
+        [TestCase("select \"abc--def\", ?, \"ghi--jki\", ? from foo", "select \"abc--def\", @p0, \"ghi--jki\", @p1 from foo")]
+        [TestCase("select \"abc//def\", ?, \"ghi//jki\", ? from foo", "select \"abc//def\", @p0, \"ghi//jki\", @p1 from foo")]
+        [TestCase("select \"abc/*def\", ?, \"ghi*/jki\", ? from foo", "select \"abc/*def\", @p0, \"ghi*/jki\", @p1 from foo")]
+        [TestCase("select [abcdef], ?, [ghijki], ? from foo", "select [abcdef], @p0, [ghijki], @p1 from foo")]
+        [TestCase("select [abc[def], ?, [ghi]]jki], ? from foo", "select [abc[def], @p0, [ghi]]jki], @p1 from foo")]
+        [TestCase("select [abc\"def], ?, [ghi\"jki], ? from foo", "select [abc\"def], @p0, [ghi\"jki], @p1 from foo")]
+        [TestCase("select [abc'def], ?, [ghi'jki], ? from foo", "select [abc'def], @p0, [ghi'jki], @p1 from foo")]
+        [TestCase("select [abc--def], ?, [ghi--jki], ? from foo", "select [abc--def], @p0, [ghi--jki], @p1 from foo")]
+        [TestCase("select [abc//def], ?, [ghi//jki], ? from foo", "select [abc//def], @p0, [ghi//jki], @p1 from foo")]
+        [TestCase("select [abc/*def], ?, [ghi*/jki], ? from foo", "select [abc/*def], @p0, [ghi*/jki], @p1 from foo")]
+        [TestCase("select /*abcdef*/, ?, /*ghijki*/, ? from foo", "select /*abcdef*/, @p0, /*ghijki*/, @p1 from foo")]
+        [TestCase("select /*abc\"def*/, ?, /*ghi\"jki*/, ? from foo", "select /*abc\"def*/, @p0, /*ghi\"jki*/, @p1 from foo")]
+        [TestCase("select /*abc'def*/, ?, /*ghi'jki*/, ? from foo", "select /*abc'def*/, @p0, /*ghi'jki*/, @p1 from foo")]
+        [TestCase("select /*abc[def*/, ?, /*ghi]jki*/, ? from foo", "select /*abc[def*/, @p0, /*ghi]jki*/, @p1 from foo")]
+        [TestCase("select /*abc--def*/, ?, /*ghi--jki*/, ? from foo", "select /*abc--def*/, @p0, /*ghi--jki*/, @p1 from foo")]
+        [TestCase("select /*abc//def*/, ?, /*ghi//jki*/, ? from foo", "select /*abc//def*/, @p0, /*ghi//jki*/, @p1 from foo")]
+        [TestCase("select /*abc/*def*/, ?, /*ghi*/jki*/, ? from foo", "select /*abc/*def*/, @p0, /*ghi*/jki*/, @p1 from foo")]
+        [TestCase("select ?, -- abcdef, ?, ghijkl, ? from foo", "select @p0, -- abcdef, ?, ghijkl, ? from foo")]
+        [TestCase("select ?, -- abcdef, ?,\n ghijkl, ? from foo", "select @p0, -- abcdef, ?,\n ghijkl, @p1 from foo")]
+        [TestCase("select ?, // abcdef, ?, ghijkl, ? from foo", "select @p0, // abcdef, ?, ghijkl, ? from foo")]
+        [TestCase("select ?, // abcdef, ?,\n ghijkl, ? from foo", "select @p0, // abcdef, ?,\n ghijkl, @p1 from foo")]
+        [TestCase("select foo.*, bar.x/bar.y [xy?! ratio], bar.a-bar.b \"ab?! difference\", -- these names are awful, what are they for?\n"
+            + " coalesce(bar.g, '/*??*/') \"abc \"\" def\" /* using block comments with ? as a null placeholder value for legacy code handling */, "
+            + " ?/?+bar-? [[var1?]]], // why are all these names so bad?  why do they all contains ?\n"
+            + " ? / ? * bar.z - ? \"\"\"var2?\"\"\"--,\n"
+            + " /* // this seems unused? commenting out for testing \n ? / ? * bar.y - ? \"\"\"var3?\"\"\" */\n"
+            + " from [table1] [foo]\n"
+            + " left join \"table2\" \"bar\" on foo.k == bar.k\n"
+            + " where bar.l == ? and bar.e == 'no value'",
+            "select foo.*, bar.x/bar.y [xy?! ratio], bar.a-bar.b \"ab?! difference\", -- these names are awful, what are they for?\n"
+            + " coalesce(bar.g, '/*??*/') \"abc \"\" def\" /* using block comments with ? as a null placeholder value for legacy code handling */, "
+            + " @p0/@p1+bar-@p2 [[var1?]]], // why are all these names so bad?  why do they all contains ?\n"
+            + " @p3 / @p4 * bar.z - @p5 \"\"\"var2?\"\"\"--,\n"
+            + " /* // this seems unused? commenting out for testing \n ? / ? * bar.y - ? \"\"\"var3?\"\"\" */\n"
+            + " from [table1] [foo]\n"
+            + " left join \"table2\" \"bar\" on foo.k == bar.k\n"
+            + " where bar.l == @p6 and bar.e == 'no value'")]
         public void ToNamedParameters_WithQuestionMarkQuery_SubstitutesCorrectly(string input, string expected)
         {
             var actual = input.ToNamedParameters();

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -307,13 +307,13 @@ END";
             Assert.AreEqual(expected, actual);
         }
 
-        [TestCaseSource(nameof(SplitQuestionMarksInvalidSqlTestInput))]
+        [TestCaseSource(nameof(ToNamedParameters_WithQuestionMarkQuery_InvalidSql_Input))]
         public void ToNamedParameters_WithQuestionMarkQuery_InvalidSql_Fails(string input)
         {
             Assert.Throws<ArgumentException>(() => input.ToNamedParameters());
         }
 
-        public static IEnumerable<object[]> SplitQuestionMarksInvalidSqlTestInput =>
+        public static IEnumerable<object[]> ToNamedParameters_WithQuestionMarkQuery_InvalidSql_Input =>
             new List<object[]>
             {
                 // Right braces are not relevant; they are only a special character when in a left-brace quoted string

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Text.RegularExpressions;
 using AdoNetCore.AseClient.Internal;
 using NUnit.Framework;
 

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -298,6 +298,8 @@ END";
         [TestCase("/*abc//def*/ghi", "/*abc//def*/ghi")]
         [TestCase("abc/*def\nghi*//jkl", "abc/*def\nghi*//jkl")]
         [TestCase("abc/*def\nghi*///jkl", "abc/*def\nghi*///jkl")]
+        [TestCase("abc//*def\n*/ghi", "abc//*def\n*/ghi")]
+        [TestCase("abc//*def*/ghi", "abc//*def*/ghi")]
         public void ToNamedParameters_WithQuestionMarkQuery_SubstitutesCorrectly(string input, string expected)
         {
             var actual = input.ToNamedParameters();
@@ -409,6 +411,8 @@ END";
                 new object[] { "/*abc//def*/ghi", new[] { "/*abc//def*/", "ghi" } },
                 new object[] { "abc/*def\nghi*//jkl", new[] { "abc", "/*def\nghi*/", "/jkl" } },
                 new object[] { "abc/*def\nghi*///jkl", new[] { "abc", "/*def\nghi*/", "//jkl" } },
+                new object[] { "abc//*def\n*/ghi", new[] { "abc", "//*def\n", "*/ghi" } },
+                new object[] { "abc//*def*/ghi", new[] { "abc", "//*def*/ghi" } },
                 new object[] { "select 'abcdef', ?, 'ghijki', ? from foo", new[] { "select ", "'abcdef'", ", ", ", ", "'ghijki'", ", ", " from foo" } },
                 new object[] { "select 'abc?def', ?, 'ghi?jki', ? from foo", new[] { "select ", "'abc?def'", ", ", ", ", "'ghi?jki'", ", ", " from foo" } },
                 new object[] { "select 'abc\"def', ?, 'ghi\"jki', ? from foo", new[] { "select ", "'abc\"def'", ", ", ", ", "'ghi\"jki'", ", ", " from foo" } },
@@ -515,6 +519,8 @@ END";
                 new object[] { "/*abc//def*/ghi", new[] { "*abc", "/def*/ghi" } },
                 new object[] { "abc/*def\nghi*//jkl", new[] { "abc", "*def\nghi*", "/jkl" } },
                 new object[] { "abc/*def\nghi*///jkl", new[] { "abc", "*def\nghi*", "/jkl" } },
+                new object[] { "abc//*def\n*/ghi", new[] { "abc", "*def\n*/ghi" } },
+                new object[] { "abc//*def*/ghi", new[] { "abc", "*def*/ghi" } },
             };
 
         // Ansi quoted sql string uses 'apostrophes' at the start and end.
@@ -641,6 +647,8 @@ END";
                 new object[] { "/*abc//def*/ghi", new[] { "/*abc//def*/" } },
                 new object[] { "abc/*def\nghi*//jkl", new[] { "/*def\nghi*/" } },
                 new object[] { "abc/*def\nghi*///jkl", new[] { "/*def\nghi*/", "//jkl" } },
+                new object[] { "abc//*def\n*/ghi", new[] { "//*def\n" } },
+                new object[] { "abc//*def*/ghi", new[] { "//*def*/ghi" } },
             };
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/NamedParamsTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Text.RegularExpressions;
 using AdoNetCore.AseClient.Internal;
 using NUnit.Framework;
 
@@ -174,6 +177,7 @@ END";
             }
         }
 
+        [TestCase("SELECT ? + ' ' + ? AS Value", "SELECT @p0 + ' ' + @p1 AS Value")]
         [TestCase("SELECT 1 FROM myTable WHERE myColumn = ?", "SELECT 1 FROM myTable WHERE myColumn = @p0")]
         [TestCase("SELECT 1 FROM myTable WHERE myColumn=?", "SELECT 1 FROM myTable WHERE myColumn=@p0")]
         [TestCase("SELECT 1, [some column ?] FROM myTable WHERE myColumn = ?", "SELECT 1, [some column ?] FROM myTable WHERE myColumn = @p0")]
@@ -189,6 +193,7 @@ END";
         [TestCase("EXEC myProc ?,?,?,?", "EXEC myProc @p0,@p1,@p2,@p3")]
         [TestCase("EXEC myProc ?, ?, ?, ?", "EXEC myProc @p0, @p1, @p2, @p3")]
         [TestCase("select 'abcdef', ?, 'ghijki', ? from foo", "select 'abcdef', @p0, 'ghijki', @p1 from foo")]
+        [TestCase("select 'abc?def', ?, 'ghi?jki', ? from foo", "select 'abc?def', @p0, 'ghi?jki', @p1 from foo")]
         [TestCase("select 'abc\"def', ?, 'ghi\"jki', ? from foo", "select 'abc\"def', @p0, 'ghi\"jki', @p1 from foo")]
         [TestCase("select 'abc''def', ?, 'ghi''jki', ? from foo", "select 'abc''def', @p0, 'ghi''jki', @p1 from foo")]
         [TestCase("select 'abc[def', ?, 'ghi]jki', ? from foo", "select 'abc[def', @p0, 'ghi]jki', @p1 from foo")]
@@ -196,6 +201,7 @@ END";
         [TestCase("select 'abc//def', ?, 'ghi//jki', ? from foo", "select 'abc//def', @p0, 'ghi//jki', @p1 from foo")]
         [TestCase("select 'abc/*def', ?, 'ghi*/jki', ? from foo", "select 'abc/*def', @p0, 'ghi*/jki', @p1 from foo")]
         [TestCase("select \"abcdef\", ?, \"ghijki\", ? from foo", "select \"abcdef\", @p0, \"ghijki\", @p1 from foo")]
+        [TestCase("select \"abc?def\", ?, \"ghi?jki\", ? from foo", "select \"abc?def\", @p0, \"ghi?jki\", @p1 from foo")]
         [TestCase("select \"abc[def\", ?, \"ghi]jki\", ? from foo", "select \"abc[def\", @p0, \"ghi]jki\", @p1 from foo")]
         [TestCase("select \"abc\"\"def\", ?, \"ghi\"\"jki\", ? from foo", "select \"abc\"\"def\", @p0, \"ghi\"\"jki\", @p1 from foo")]
         [TestCase("select \"abc'def\", ?, \"ghi'jki\", ? from foo", "select \"abc'def\", @p0, \"ghi'jki\", @p1 from foo")]
@@ -203,6 +209,7 @@ END";
         [TestCase("select \"abc//def\", ?, \"ghi//jki\", ? from foo", "select \"abc//def\", @p0, \"ghi//jki\", @p1 from foo")]
         [TestCase("select \"abc/*def\", ?, \"ghi*/jki\", ? from foo", "select \"abc/*def\", @p0, \"ghi*/jki\", @p1 from foo")]
         [TestCase("select [abcdef], ?, [ghijki], ? from foo", "select [abcdef], @p0, [ghijki], @p1 from foo")]
+        [TestCase("select [abc?def], ?, [ghi?jki], ? from foo", "select [abc?def], @p0, [ghi?jki], @p1 from foo")]
         [TestCase("select [abc[def], ?, [ghi]]jki], ? from foo", "select [abc[def], @p0, [ghi]]jki], @p1 from foo")]
         [TestCase("select [abc\"def], ?, [ghi\"jki], ? from foo", "select [abc\"def], @p0, [ghi\"jki], @p1 from foo")]
         [TestCase("select [abc'def], ?, [ghi'jki], ? from foo", "select [abc'def], @p0, [ghi'jki], @p1 from foo")]
@@ -210,6 +217,7 @@ END";
         [TestCase("select [abc//def], ?, [ghi//jki], ? from foo", "select [abc//def], @p0, [ghi//jki], @p1 from foo")]
         [TestCase("select [abc/*def], ?, [ghi*/jki], ? from foo", "select [abc/*def], @p0, [ghi*/jki], @p1 from foo")]
         [TestCase("select /*abcdef*/, ?, /*ghijki*/, ? from foo", "select /*abcdef*/, @p0, /*ghijki*/, @p1 from foo")]
+        [TestCase("select /*abc?def*/, ?, /*ghi?jki*/, ? from foo", "select /*abc?def*/, @p0, /*ghi?jki*/, @p1 from foo")]
         [TestCase("select /*abc\"def*/, ?, /*ghi\"jki*/, ? from foo", "select /*abc\"def*/, @p0, /*ghi\"jki*/, @p1 from foo")]
         [TestCase("select /*abc'def*/, ?, /*ghi'jki*/, ? from foo", "select /*abc'def*/, @p0, /*ghi'jki*/, @p1 from foo")]
         [TestCase("select /*abc[def*/, ?, /*ghi]jki*/, ? from foo", "select /*abc[def*/, @p0, /*ghi]jki*/, @p1 from foo")]
@@ -236,11 +244,403 @@ END";
             + " from [table1] [foo]\n"
             + " left join \"table2\" \"bar\" on foo.k == bar.k\n"
             + " where bar.l == @p6 and bar.e == 'no value'")]
+        // The following aren't really valid sql, but are useful for testing that the parameteriser is well-behaved in weird cases
+        [TestCase("", "")]
+        [TestCase("abcdef", "abcdef")]
+        // TODO: the way parameters get accidentally merged looks suspicious, possibly append space to the end of them to prevent this type of corruption?
+        // In practice this shouldn't happen, as parameters should always be followed by whitespace or symbols
+        // eg select ? + foo.y, ?/foo.z, coalesce(foo.x, ?) from table1 foo where foo.a=?
+        [TestCase("ab?cdef", "ab@p0cdef")]
+        [TestCase("?abcdef", "@p0abcdef")]
+        [TestCase("abcdef?", "abcdef@p0")]
+        [TestCase("?abcdef?", "@p0abcdef@p1")]
+        [TestCase("ab?cd?ef", "ab@p0cd@p1ef")]
+        [TestCase("ab?c?d?ef", "ab@p0c@p1d@p2ef")]
+        [TestCase("ab''cdef", "ab''cdef")]
+        [TestCase("ab''''cdef", "ab''''cdef")]
+        [TestCase("''abcdef", "''abcdef")]
+        [TestCase("abcdef''", "abcdef''")]
+        [TestCase("'abcdef'", "'abcdef'")]
+        [TestCase("'abc?def'", "'abc?def'")]
+        [TestCase("ab'cd'ef", "ab'cd'ef")]
+        [TestCase("ab'c''d'ef", "ab'c''d'ef")]
+        [TestCase("ab\"\"cdef", "ab\"\"cdef")]
+        [TestCase("ab\"\"\"\"cdef", "ab\"\"\"\"cdef")]
+        [TestCase("\"\"abcdef", "\"\"abcdef")]
+        [TestCase("abcdef\"\"", "abcdef\"\"")]
+        [TestCase("\"abcdef\"", "\"abcdef\"")]
+        [TestCase("\"abc?def\"", "\"abc?def\"")]
+        [TestCase("ab\"cd\"ef", "ab\"cd\"ef")]
+        [TestCase("ab\"c\"\"d\"ef", "ab\"c\"\"d\"ef")]
+        [TestCase("ab[]cdef", "ab[]cdef")]
+        [TestCase("ab[]]]cdef", "ab[]]]cdef")]
+        [TestCase("[]abcdef", "[]abcdef")]
+        [TestCase("abcdef[]", "abcdef[]")]
+        [TestCase("[abcdef]", "[abcdef]")]
+        [TestCase("[abc?def]", "[abc?def]")]
+        [TestCase("ab[cd]ef", "ab[cd]ef")]
+        [TestCase("ab[c]]d]ef", "ab[c]]d]ef")]
+        [TestCase("ab[c]]?d]ef", "ab[c]]?d]ef")]
+        [TestCase("abc/def", "abc/def")]
+        [TestCase("abc-def", "abc-def")]
+        [TestCase("--abcdef", "--abcdef")]
+        [TestCase("--abc?def", "--abc?def")]
+        [TestCase("-/-abcdef", "-/-abcdef")]
+        [TestCase("-/-abc?def", "-/-abc@p0def")]
+        [TestCase("abc--def", "abc--def")]
+        [TestCase("abc-/-def", "abc-/-def")]
+        [TestCase("--abcdef\n", "--abcdef\n")]
+        [TestCase("abc--def\n", "abc--def\n")]
+        [TestCase("/*abcdef*/", "/*abcdef*/")]
+        [TestCase("/*abc?def*/", "/*abc?def*/")]
+        [TestCase("/-*abcdef*/", "/-*abcdef*/")]
+        [TestCase("/-*abc?def*/", "/-*abc@p0def*/")]
+        [TestCase("/*abc//def*/ghi", "/*abc//def*/ghi")]
+        [TestCase("abc/*def\nghi*//jkl", "abc/*def\nghi*//jkl")]
+        [TestCase("abc/*def\nghi*///jkl", "abc/*def\nghi*///jkl")]
         public void ToNamedParameters_WithQuestionMarkQuery_SubstitutesCorrectly(string input, string expected)
         {
             var actual = input.ToNamedParameters();
 
             Assert.AreEqual(expected, actual);
         }
+
+        [TestCaseSource(nameof(SplitQuestionMarksInvalidSqlTestInput))]
+        public void ToNamedParameters_WithQuestionMarkQuery_InvalidSql_Fails(string input)
+        {
+            Assert.Throws<ArgumentException>(() => input.ToNamedParameters());
+        }
+
+        public static IEnumerable<object[]> SplitQuestionMarksInvalidSqlTestInput =>
+            new List<object[]>
+            {
+                // Right braces are not relevant; they are only a special character when in a left-brace quoted string
+                new object[] { "[unbalanced brace" },
+                new object[] { "'unbalanced apostrophe" },
+                new object[] { "\"unbalanced quote" },
+                new object[] { "/*unbalanced comment" },
+            };
+
+        private void AssertRegexMatches(string pattern, string input, string[] expected)
+        {
+            var regex = new Regex(pattern, RegexOptions.Singleline);
+            MatchCollection matches = regex.Matches(input);
+            string[] actual = new string[matches.Count];
+            for (int i = 0; i < matches.Count; i++)
+            {
+                actual[i] = matches[i].Value;
+            }
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        // SqlPart tokenizes the string into individual chunks of sql:
+        // comments, strings, quoted identifiers, and unspecified (i.e strings of sql keywords)
+        // Question mark parameters are ignored, but still cause a split
+        [TestCaseSource(nameof(SqlPartTestInput))]
+        public void SqlPartTest(string input, string[] expected)
+        {
+            AssertRegexMatches(NamedParametersExtensions.SqlPart, input, expected);
+        }
+
+        public static IEnumerable<object[]> SqlPartTestInput =>
+            new List<object[]>
+            {
+                new object[] { "SELECT ? + ' ' + ? AS Value", new[] { "SELECT ", " + ", "' '", " + ", " AS Value" } },
+                new object[] { "SELECT 1 FROM myTable WHERE myColumn = ?", new[] { "SELECT 1 FROM myTable WHERE myColumn = " } },
+                new object[] { "SELECT 1 FROM myTable WHERE myColumn=?", new[] { "SELECT 1 FROM myTable WHERE myColumn=" } },
+                new object[] { "SELECT 1, [some column ?] FROM myTable WHERE myColumn = ?", new[] { "SELECT 1, ", "[some column ?]", " FROM myTable WHERE myColumn = " } },
+                new object[] { @"SELECT 1, ""What is going on ?"" FROM myTable WHERE myColumn = ?", new[] { @"SELECT 1, ", @"""What is going on ?""", @" FROM myTable WHERE myColumn = " } },
+                new object[] { "SELECT 1, 'What is going on ?' FROM myTable WHERE myColumn = ?", new[] { "SELECT 1, ", "'What is going on ?'", " FROM myTable WHERE myColumn = " } },
+                new object[] { "SELECT 1 FROM myTable WHERE myColumn1 = ? AND myColumn2 = ?", new[] { "SELECT 1 FROM myTable WHERE myColumn1 = ", " AND myColumn2 = " } },
+                new object[] { "SELECT 1 FROM myTable WHERE myColumn1 = ? AND myColumn2 = 'A question?' AND myColumn3 = ?", new[] { "SELECT 1 FROM myTable WHERE myColumn1 = ", " AND myColumn2 = ", "'A question?'", " AND myColumn3 = " } },
+                new object[] { "SELECT 1, 'What is going on ?', \"What is going on ?\", [What is going on ?] FROM myTable WHERE myColumn = ?", new[] { "SELECT 1, ", "'What is going on ?'", ", ", "\"What is going on ?\"", ", ", "[What is going on ?]", " FROM myTable WHERE myColumn = " } },
+                new object[] { "SELECT 1, 'What is going on \"arggh\"', \"What is going on ?\" FROM myTable WHERE myColumn = ?", new[] { "SELECT 1, ", "'What is going on \"arggh\"'", ", ", "\"What is going on ?\"", " FROM myTable WHERE myColumn = " } },
+                new object[] { "SELECT 1, 'What is going on \"arggh', \"What is going on ?\" FROM myTable WHERE myColumn = ?", new[] { "SELECT 1, ", "'What is going on \"arggh'", ", ", "\"What is going on ?\"", " FROM myTable WHERE myColumn = " } },
+                new object[] { "SELECT 1, 'What is going on \"arggh?', \"What is going on ?\" FROM myTable WHERE myColumn = ?", new[] { "SELECT 1, ", "'What is going on \"arggh?'", ", ", "\"What is going on ?\"", " FROM myTable WHERE myColumn = " } },
+                new object[] { "SELECT 1, 'What is going on \"arggh?\"', \"What is going on ?\" FROM myTable WHERE myColumn = ?", new[] { "SELECT 1, ", "'What is going on \"arggh?\"'", ", ", "\"What is going on ?\"", " FROM myTable WHERE myColumn = " } },
+                new object[] { "EXEC myProc ?,?,?,?", new[] { "EXEC myProc ", ",", ",", "," } },
+                new object[] { "EXEC myProc ?, ?, ?, ?", new[] { "EXEC myProc ", ", ", ", ", ", " } },
+                new object[] { "ab?cdef", new[] { "ab", "cdef" } },
+                new object[] { "?abcdef", new[] { "abcdef" } },
+                new object[] { "abcdef", new[] { "abcdef" } },
+                new object[] { "abcdef?", new[] { "abcdef" } },
+                new object[] { "?abcdef?", new[] { "abcdef" } },
+                new object[] { "ab?cd?ef", new[] { "ab", "cd", "ef" } },
+                new object[] { "ab?c?d?ef", new[] { "ab", "c", "d", "ef" } },
+                new object[] { "ab''cdef", new[] { "ab", "''", "cdef" } },
+                new object[] { "ab''''cdef", new[] { "ab", "''''", "cdef" } },
+                new object[] { "''abcdef", new[] { "''", "abcdef" } },
+                new object[] { "abcdef''", new[] { "abcdef", "''" } },
+                new object[] { "'abcdef'", new[] { "'abcdef'" } },
+                new object[] { "'abc?def'", new[] { "'abc?def'" } },
+                new object[] { "ab'cd'ef", new[] { "ab", "'cd'", "ef" } },
+                new object[] { "ab'c''d'ef", new[] { "ab", "'c''d'", "ef" } },
+                new object[] { "ab\"\"cdef", new[] { "ab", "\"\"", "cdef" } },
+                new object[] { "ab\"\"\"\"cdef", new[] { "ab", "\"\"\"\"", "cdef" } },
+                new object[] { "\"\"abcdef", new[] { "\"\"", "abcdef" } },
+                new object[] { "abcdef\"\"", new[] { "abcdef", "\"\"" } },
+                new object[] { "\"abcdef\"", new[] { "\"abcdef\"" } },
+                new object[] { "\"abc?def\"", new[] { "\"abc?def\"" } },
+                new object[] { "ab\"cd\"ef", new[] { "ab", "\"cd\"", "ef" } },
+                new object[] { "ab\"c\"\"d\"ef", new[] { "ab", "\"c\"\"d\"", "ef" } },
+                new object[] { "ab[]cdef", new[] { "ab", "[]", "cdef" } },
+                new object[] { "ab[]]]cdef", new[] { "ab", "[]]]", "cdef" } },
+                new object[] { "[]abcdef", new[] { "[]", "abcdef" } },
+                new object[] { "abcdef[]", new[] { "abcdef", "[]" } },
+                new object[] { "[abcdef]", new[] { "[abcdef]" } },
+                new object[] { "[abc?def]", new[] { "[abc?def]" } },
+                new object[] { "ab[cd]ef", new[] { "ab", "[cd]", "ef" } },
+                new object[] { "ab[c]]d]ef", new[] { "ab", "[c]]d]", "ef" } },
+                new object[] { "ab[c]]?d]ef", new[] { "ab", "[c]]?d]", "ef" } },
+                new object[] { "abc/def", new[] { "abc/def" } },
+                new object[] { "abc-def", new[] { "abc-def" } },
+                new object[] { "--abcdef", new[] { "--abcdef" } },
+                new object[] { "--abc?def", new[] { "--abc?def" } },
+                new object[] { "-/-abcdef", new[] { "-/-abcdef" } },
+                new object[] { "-/-abc?def", new[] { "-/-abc", "def" } },
+                new object[] { "abc--def", new[] { "abc", "--def" } },
+                new object[] { "abc-/-def", new[] { "abc-/-def" } },
+                new object[] { "--abcdef\n", new[] { "--abcdef\n" } },
+                new object[] { "abc--def\n", new[] { "abc", "--def\n" } },
+                new object[] { "/*abcdef*/", new[] { "/*abcdef*/" } },
+                new object[] { "/*abc?def*/", new[] { "/*abc?def*/" } },
+                new object[] { "/-*abcdef*/", new[] { "/-*abcdef*/" } },
+                new object[] { "/-*abc?def*/", new[] { "/-*abc", "def*/" } },
+                new object[] { "/*abc//def*/ghi", new[] { "/*abc//def*/", "ghi" } },
+                new object[] { "abc/*def\nghi*//jkl", new[] { "abc", "/*def\nghi*/", "/jkl" } },
+                new object[] { "abc/*def\nghi*///jkl", new[] { "abc", "/*def\nghi*/", "//jkl" } },
+                new object[] { "select 'abcdef', ?, 'ghijki', ? from foo", new[] { "select ", "'abcdef'", ", ", ", ", "'ghijki'", ", ", " from foo" } },
+                new object[] { "select 'abc?def', ?, 'ghi?jki', ? from foo", new[] { "select ", "'abc?def'", ", ", ", ", "'ghi?jki'", ", ", " from foo" } },
+                new object[] { "select 'abc\"def', ?, 'ghi\"jki', ? from foo", new[] { "select ", "'abc\"def'", ", ", ", ", "'ghi\"jki'", ", ", " from foo" } },
+                new object[] { "select 'abc''def', ?, 'ghi''jki', ? from foo", new[] { "select ", "'abc''def'", ", ", ", ", "'ghi''jki'", ", ", " from foo" } },
+                new object[] { "select 'abc[def', ?, 'ghi]jki', ? from foo", new[] { "select ", "'abc[def'", ", ", ", ", "'ghi]jki'", ", ", " from foo" } },
+                new object[] { "select 'abc--def', ?, 'ghi--jki', ? from foo", new[] { "select ", "'abc--def'", ", ", ", ", "'ghi--jki'", ", ", " from foo" } },
+                new object[] { "select 'abc//def', ?, 'ghi//jki', ? from foo", new[] { "select ", "'abc//def'", ", ", ", ", "'ghi//jki'", ", ", " from foo" } },
+                new object[] { "select 'abc/*def', ?, 'ghi*/jki', ? from foo", new[] { "select ", "'abc/*def'", ", ", ", ", "'ghi*/jki'", ", ", " from foo" } },
+                new object[] { "select \"abcdef\", ?, \"ghijki\", ? from foo", new[] { "select ", "\"abcdef\"", ", ", ", ", "\"ghijki\"", ", ", " from foo" } },
+                new object[] { "select \"abc?def\", ?, \"ghi?jki\", ? from foo", new[] { "select ", "\"abc?def\"", ", ", ", ", "\"ghi?jki\"", ", ", " from foo" } },
+                new object[] { "select \"abc[def\", ?, \"ghi]jki\", ? from foo", new[] { "select ", "\"abc[def\"", ", ", ", ", "\"ghi]jki\"", ", ", " from foo" } },
+                new object[] { "select \"abc\"\"def\", ?, \"ghi\"\"jki\", ? from foo", new[] { "select ", "\"abc\"\"def\"", ", ", ", ", "\"ghi\"\"jki\"", ", ", " from foo" } },
+                new object[] { "select \"abc'def\", ?, \"ghi'jki\", ? from foo", new[] { "select ", "\"abc'def\"", ", ", ", ", "\"ghi'jki\"", ", ", " from foo" } },
+                new object[] { "select \"abc--def\", ?, \"ghi--jki\", ? from foo", new[] { "select ", "\"abc--def\"", ", ", ", ", "\"ghi--jki\"", ", ", " from foo" } },
+                new object[] { "select \"abc//def\", ?, \"ghi//jki\", ? from foo", new[] { "select ", "\"abc//def\"", ", ", ", ", "\"ghi//jki\"", ", ", " from foo" } },
+                new object[] { "select \"abc/*def\", ?, \"ghi*/jki\", ? from foo", new[] { "select ", "\"abc/*def\"", ", ", ", ", "\"ghi*/jki\"", ", ", " from foo" } },
+                new object[] { "select [abcdef], ?, [ghijki], ? from foo", new[] { "select ", "[abcdef]", ", ", ", ", "[ghijki]", ", ", " from foo" } },
+                new object[] { "select [abc?def], ?, [ghi?jki], ? from foo", new[] { "select ", "[abc?def]", ", ", ", ", "[ghi?jki]", ", ", " from foo" } },
+                new object[] { "select [abc[def], ?, [ghi]]jki], ? from foo", new[] { "select ", "[abc[def]", ", ", ", ", "[ghi]]jki]", ", ", " from foo" } },
+                new object[] { "select [abc\"def], ?, [ghi\"jki], ? from foo", new[] { "select ", "[abc\"def]", ", ", ", ", "[ghi\"jki]", ", ", " from foo" } },
+                new object[] { "select [abc'def], ?, [ghi'jki], ? from foo", new[] { "select ", "[abc'def]", ", ", ", ", "[ghi'jki]", ", ", " from foo" } },
+                new object[] { "select [abc--def], ?, [ghi--jki], ? from foo", new[] { "select ", "[abc--def]", ", ", ", ", "[ghi--jki]", ", ", " from foo" } },
+                new object[] { "select [abc//def], ?, [ghi//jki], ? from foo", new[] { "select ", "[abc//def]", ", ", ", ", "[ghi//jki]", ", ", " from foo" } },
+                new object[] { "select [abc/*def], ?, [ghi*/jki], ? from foo", new[] { "select ", "[abc/*def]", ", ", ", ", "[ghi*/jki]", ", ", " from foo" } },
+                new object[] { "select /*abcdef*/, ?, /*ghijki*/, ? from foo", new[] { "select ", "/*abcdef*/", ", ", ", ", "/*ghijki*/", ", ", " from foo" } },
+                new object[] { "select /*abc?def*/, ?, /*ghi?jki*/, ? from foo", new[] { "select ", "/*abc?def*/", ", ", ", ", "/*ghi?jki*/", ", ", " from foo" } },
+                new object[] { "select /*abc\"def*/, ?, /*ghi\"jki*/, ? from foo", new[] { "select ", "/*abc\"def*/", ", ", ", ", "/*ghi\"jki*/", ", ", " from foo" } },
+                new object[] { "select /*abc'def*/, ?, /*ghi'jki*/, ? from foo", new[] { "select ", "/*abc'def*/", ", ", ", ", "/*ghi'jki*/", ", ", " from foo" } },
+                new object[] { "select /*abc[def*/, ?, /*ghi]jki*/, ? from foo", new[] { "select ", "/*abc[def*/", ", ", ", ", "/*ghi]jki*/", ", ", " from foo" } },
+                new object[] { "select /*abc--def*/, ?, /*ghi--jki*/, ? from foo", new[] { "select ", "/*abc--def*/", ", ", ", ", "/*ghi--jki*/", ", ", " from foo" } },
+                new object[] { "select /*abc//def*/, ?, /*ghi//jki*/, ? from foo", new[] { "select ", "/*abc//def*/", ", ", ", ", "/*ghi//jki*/", ", ", " from foo" } },
+                new object[] { "select /*abc/*def*/, ?, /*ghi*/jki*/, ? from foo", new[] { "select ", "/*abc/*def*/", ", ", ", ", "/*ghi*/", "jki*/, ", " from foo" } },
+                new object[] { "select ?, -- abcdef, ?, ghijkl, ? from foo", new[] { "select ", ", ", "-- abcdef, ?, ghijkl, ? from foo" } },
+                new object[] { "select ?, -- abcdef, ?,\n ghijkl, ? from foo", new[] { "select ", ", ", "-- abcdef, ?,\n", " ghijkl, ", " from foo" } },
+                new object[] { "select ?, // abcdef, ?, ghijkl, ? from foo", new[] { "select ", ", ", "// abcdef, ?, ghijkl, ? from foo" } },
+                new object[] { "select ?, // abcdef, ?,\n ghijkl, ? from foo", new[] { "select ", ", ", "// abcdef, ?,\n", " ghijkl, ", " from foo" } },
+                new object[] {
+                    "select foo.*, bar.x/bar.y [xy?! ratio], bar.a-bar.b \"ab?! difference\", -- these names are awful, what are they for?\n"
+                    + " coalesce(bar.g, '/*??*/') \"abc \"\" def\" /* using block comments with ? as a null placeholder value for legacy code handling */, "
+                    + " ?/?+bar-? [[var1?]]], // why are all these names so bad?  why do they all contains ?\n"
+                    + " ? / ? * bar.z - ? \"\"\"var2?\"\"\"--,\n"
+                    + " /* // this seems unused? commenting out for testing \n ? / ? * bar.y - ? \"\"\"var3?\"\"\" */\n"
+                    + " from [table1] [foo]\n"
+                    + " left join \"table2\" \"bar\" on foo.k == bar.k\n"
+                    + " where bar.l == ? and bar.e == 'no value'",
+                    new[] {
+                        "select foo.*, bar.x/bar.y ", "[xy?! ratio]", ", bar.a-bar.b ", "\"ab?! difference\"", ", ", "-- these names are awful, what are they for?\n",
+                        " coalesce(bar.g, ", "'/*??*/'", ") ", "\"abc \"\" def\"", " ", "/* using block comments with ? as a null placeholder value for legacy code handling */",
+                        ",  ", "/", "+bar-", " ", "[[var1?]]]", ", ", "// why are all these names so bad?  why do they all contains ?\n",
+                        " ", " / ", " * bar.z - ", " ", "\"\"\"var2?\"\"\"", "--,\n",
+                        " ", "/* // this seems unused? commenting out for testing \n ? / ? * bar.y - ? \"\"\"var3?\"\"\" */",
+                        "\n from ", "[table1]", " ", "[foo]",
+                        "\n left join ", "\"table2\"", " ", "\"bar\"",
+                        " on foo.k == bar.k\n where bar.l == ", " and bar.e == ", "'no value'" }
+                },
+            };
+
+        // SimpleSql extracts parts of the input string are are not special to our purposes,
+        // i.e. everything that is not a comment, string, quoted identifier, or question mark
+        [TestCaseSource(nameof(SimpleSqlPartTestInput))]
+        public void SimpleSqlPartTest(string input, string[] expected)
+        {
+            AssertRegexMatches(NamedParametersExtensions.SimpleSqlPart, input, expected);
+        }
+
+        public static IEnumerable<object[]> SimpleSqlPartTestInput =>
+            new List<object[]>
+            {
+                new object[] { "ab?cdef", new[] { "ab", "cdef" } },
+                new object[] { "?abcdef", new[] { "abcdef" } },
+                new object[] { "abcdef?", new[] { "abcdef" } },
+                new object[] { "?abcdef?", new[] { "abcdef" } },
+                new object[] { "ab?cd?ef", new[] { "ab", "cd", "ef" } },
+                new object[] { "ab?c?d?ef", new[] { "ab", "c", "d", "ef" } },
+                new object[] { "ab''cdef", new[] { "ab", "cdef" } },
+                new object[] { "''abcdef", new[] { "abcdef" } },
+                new object[] { "abcdef''", new[] { "abcdef" } },
+                new object[] { "'abcdef'", new[] { "abcdef" } },
+                new object[] { "ab'cd'ef", new[] { "ab", "cd", "ef" } },
+                new object[] { "ab'c''d'ef", new[] { "ab", "c", "d", "ef" } },
+                new object[] { "ab\"\"cdef", new[] { "ab", "cdef" } },
+                new object[] { "\"\"abcdef", new[] { "abcdef" } },
+                new object[] { "abcdef\"\"", new[] { "abcdef" } },
+                new object[] { "\"abcdef\"", new[] { "abcdef" } },
+                new object[] { "ab\"cd\"ef", new[] { "ab", "cd", "ef" } },
+                new object[] { "ab\"c\"\"d\"ef", new[] { "ab", "c", "d", "ef" } },
+                new object[] { "ab[]cdef", new[] { "ab", "]cdef" } },
+                new object[] { "[]abcdef", new[] { "]abcdef" } },
+                new object[] { "abcdef[]", new[] { "abcdef", "]" } },
+                new object[] { "[abcdef]", new[] { "abcdef]" } },
+                new object[] { "ab[cd]ef", new[] { "ab", "cd]ef" } },
+                new object[] { "ab[c]]d]ef", new[] { "ab", "c]]d]ef" } },
+                new object[] { "abc/def", new[] { "abc/def" } },
+                new object[] { "abc-def", new[] { "abc-def" } },
+                new object[] { "--abcdef", new[] { "-abcdef" } },
+                new object[] { "-/-abcdef", new[] { "-/-abcdef" } },
+                new object[] { "abc--def", new[] { "abc", "-def" } },
+                new object[] { "abc-/-def", new[] { "abc-/-def" } },
+                new object[] { "--abcdef\n", new[] { "-abcdef\n" } },
+                new object[] { "abc--def\n", new[] { "abc", "-def\n" } },
+                new object[] { "/*abcdef*/", new[] { "*abcdef*/" } },
+                new object[] { "/-*abcdef*/", new[] { "/-*abcdef*/" } },
+                new object[] { "/*abcdef*-/", new[] { "*abcdef*-/" } },
+                new object[] { "/*abc//def*/ghi", new[] { "*abc", "/def*/ghi" } },
+                new object[] { "abc/*def\nghi*//jkl", new[] { "abc", "*def\nghi*", "/jkl" } },
+                new object[] { "abc/*def\nghi*///jkl", new[] { "abc", "*def\nghi*", "/jkl" } },
+            };
+
+        // Ansi quoted sql string uses 'apostrophes' at the start and end.
+        // Double apostrophe 'foo''bar' is an escaped apostrophe within the string
+        [TestCaseSource(nameof(AnsiStringTestInput))]
+        public void AnsiStringTest(string input, string[] expected)
+        {
+            AssertRegexMatches(NamedParametersExtensions.AnsiString, input, expected);
+        }
+
+        public static IEnumerable<object[]> AnsiStringTestInput =>
+            new List<object[]>
+            {
+                new object[] { "'abcdef", new string[0] },
+                new object[] { "abcdef'", new string[0] },
+                new object[] { "ab'cdef", new string[0] },
+                new object[] { "ab'cdef", new string[0] },
+                new object[] { "ab''cdef", new[] { "''" } },
+                new object[] { "ab''''cdef", new[] { "''''" } },
+                new object[] { "''abcdef", new[] { "''" } },
+                new object[] { "abcdef''", new[] { "''" } },
+                new object[] { "'abcdef'", new[] { "'abcdef'" } },
+                new object[] { "ab'cd'ef", new[] { "'cd'" } },
+                new object[] { "ab'c''d'ef", new[] { "'c''d'" } },
+                new object[] { "ab'c'd'ef", new[] { "'c'" } },
+            };
+
+        // Ansi quoted identifier uses "quotes" at the start and end.
+        // Double quotes "foo""bar" is an escaped quote within the identifier
+        [TestCaseSource(nameof(AnsiQuotedIdentifierTestInput))]
+        public void AnsiQuotedIdentifierTest(string input, string[] expected)
+        {
+            AssertRegexMatches(NamedParametersExtensions.AnsiQuotedIdentifier, input, expected);
+        }
+
+        public static IEnumerable<object[]> AnsiQuotedIdentifierTestInput =>
+            new List<object[]>
+            {
+                new object[] { "\"abcdef", new string[0] },
+                new object[] { "abcdef\"", new string[0] },
+                new object[] { "ab\"cdef", new string[0] },
+                new object[] { "ab\"cdef", new string[0] },
+                new object[] { "ab\"\"cdef", new[] { "\"\"" } },
+                new object[] { "\"\"abcdef", new[] { "\"\"" } },
+                new object[] { "abcdef\"\"", new[] { "\"\"" } },
+                new object[] { "\"abcdef\"", new[] { "\"abcdef\"" } },
+                new object[] { "ab\"cd\"ef", new[] { "\"cd\"" } },
+                new object[] { "ab\"c\"\"d\"ef", new[] { "\"c\"\"d\"" } },
+                new object[] { "ab\"c\"d\"ef", new[] { "\"c\"" } },
+            };
+
+        // Square quoted identifier uses [square brackets] at the start and end.
+        // Double right braket [foo]]bar] is an escaped square quote within the identifier
+        [TestCaseSource(nameof(SquareQuotedIdentifierTestInput))]
+        public void SquareQuotedIdentifierTest(string input, string[] expected)
+        {
+            AssertRegexMatches(NamedParametersExtensions.SquareQuotedIdentifier, input, expected);
+        }
+
+        public static IEnumerable<object[]> SquareQuotedIdentifierTestInput =>
+            new List<object[]>
+            {
+                new object[] { "[abcdef", new string[0] },
+                new object[] { "abcdef[", new string[0] },
+                new object[] { "]abcdef", new string[0] },
+                new object[] { "abcdef]", new string[0] },
+                new object[] { "ab[cdef", new string[0] },
+                new object[] { "ab]cdef", new string[0] },
+                new object[] { "]abcdef[", new string[0] },
+                new object[] { "ab[]cdef", new[] { "[]" } },
+                new object[] { "[]abcdef", new[] { "[]" } },
+                new object[] { "abcdef[]", new[] { "[]" } },
+                new object[] { "[abcdef]", new[] { "[abcdef]" } },
+                new object[] { "ab[cd]ef", new[] { "[cd]" } },
+                new object[] { "ab[c]]d]ef", new[] { "[c]]d]" } },
+                new object[] { "ab[c]d]ef", new[] { "[c]" } },
+            };
+
+        // Ansi comment is -- to the end of the line or input (whichever is first)
+        [TestCaseSource(nameof(AnsiLineCommentTestInput))]
+        public void AnsiLineCommentTest(string input, string[] expected)
+        {
+            AssertRegexMatches(NamedParametersExtensions.AnsiLineComment, input, expected);
+        }
+
+        public static IEnumerable<object[]> AnsiLineCommentTestInput =>
+            new List<object[]>
+            {
+                new object[] { "--abcdef", new[] { "--abcdef" } },
+                new object[] { "-/-abcdef", new string[0] },
+                new object[] { "abc--def", new[] { "--def" } },
+                new object[] { "abc-/-def", new string[0] },
+                new object[] { "--abcdef\n", new[] { "--abcdef\n" } },
+                new object[] { "abc--def\n", new[] { "--def\n" } },
+                new object[] { "--abc\ndef--ghi", new[] { "--abc\n", "--ghi" } },
+                new object[] { "abc--def\n--ghi", new[] { "--def\n", "--ghi" } },
+                new object[] { "abc--def\nghi--jkl", new[] { "--def\n", "--jkl" } },
+            };
+
+        // C comment is one of:
+        // Line comment // to the end of the line or input (whichever is first)
+        // Block Comment /* until first */
+        [TestCaseSource(nameof(CCommentTestInput))]
+        public void CCommentTest(string input, string[] expected)
+        {
+            AssertRegexMatches(NamedParametersExtensions.CComment, input, expected);
+        }
+
+        public static IEnumerable<object[]> CCommentTestInput =>
+            new List<object[]>
+            {
+                new object[] { "/-/abcdef", new string[0] },
+                new object[] { "//abcdef", new[] { "//abcdef" } },
+                new object[] { "abc//def", new[] { "//def" } },
+                new object[] { "abc/-/def", new string[0] },
+                new object[] { "//abcdef\n", new[] { "//abcdef\n" } },
+                new object[] { "abc//def\n", new[] { "//def\n" } },
+                new object[] { "//abc\ndef//ghi", new[] { "//abc\n", "//ghi" } },
+                new object[] { "abc//def\n//ghi", new[] { "//def\n", "//ghi" } },
+                new object[] { "abc//def\nghi//jkl", new[] { "//def\n", "//jkl" } },
+                new object[] { "/*abcdef*/", new[] { "/*abcdef*/" } },
+                new object[] { "/-*abcdef*/", new string[0] },
+                new object[] { "/*abcdef*-/", new string[0] },
+                new object[] { "/*abc//def*/ghi", new[] { "/*abc//def*/" } },
+                new object[] { "abc/*def\nghi*//jkl", new[] { "/*def\nghi*/" } },
+                new object[] { "abc/*def\nghi*///jkl", new[] { "/*def\nghi*/", "//jkl" } },
+            };
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/ConnectionPoolTests.cs
@@ -175,6 +175,8 @@ namespace AdoNetCore.AseClient.Tests.Unit
             public string Database { get; }
             public string DataSource { get; }
             public string ServerVersion { get; }
+            public bool NamedParameters { get; set; }
+
             public int ExecuteNonQuery(AseCommand command, AseTransaction transaction)
             {
                 return 0;
@@ -253,6 +255,8 @@ namespace AdoNetCore.AseClient.Tests.Unit
             public bool EncryptPassword { get; } = false;
             public bool AnsiNull { get; } = false;
             public bool EnableServerPacketSize { get; } = true;
+
+            public bool NamedParameters { get; } = true;
         }
     }
 }


### PR DESCRIPTION
More reliably replace parameters by tokenizing the entire query string with a single regexp first.