### PR TITLE
Remove nuget package warnings for icon and license URLs

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -6,9 +6,9 @@
     <FileVersion>$(VersionPrefix)</FileVersion>
     <Authors>dataaction</Authors>
     <PackageTags>Sybase ASE Adaptive SAP AseClient DbProvider</PackageTags>
-    <PackageIconUrl>https://raw.githubusercontent.com/DataAction/AdoNetCore.AseClient/master/icon.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/DataAction/AdoNetCore.AseClient</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/DataAction/AdoNetCore.AseClient/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReleaseNotes>Refer to GitHub - https://github.com/DataAction/AdoNetCore.AseClient/releases/tag/0.15.0</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/DataAction/AdoNetCore.AseClient</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -41,5 +41,8 @@
     <PackageReference Include="System.Security.Permissions">
       <Version>4.5.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../../icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes issue #146 