### PR TITLE
Implement TDS_BLOB support

### DIFF
--- a/src/AdoNetCore.AseClient/Enum/BlobType.cs
+++ b/src/AdoNetCore.AseClient/Enum/BlobType.cs
@@ -1,0 +1,33 @@
+// ReSharper disable InconsistentNaming
+namespace AdoNetCore.AseClient.Enum
+{
+    public enum BlobType : byte
+    {
+        /// <summary>
+        /// Not set
+        /// </summary>
+        BLOB_UNSET = 0x00,
+        /// <summary>
+        /// The fully qualified name of the class (“com.foo.Bar”).
+        /// This is a Character String in the negotiated TDS character set currently in use on this connection.
+        /// </summary>
+        BLOB_FULLY_QUALIFIED_CLASS_NAME = 0x01,
+        /// <summary>
+        /// 4-byte integer (database ID) 4-byte integer(sysextypes number of this class definition in this database).
+        /// Both integers are in the byte-ordering negotiated for this connection.
+        /// </summary>
+        BLOB_INT32_CLASS_ID = 0x02,
+        /// <summary>
+        /// This is long character data and has no ClassID associated with it
+        /// </summary>
+        BLOB_LONGCHAR = 0x03,
+        /// <summary>
+        ///  This is long binary data and has no ClassID associated with it.
+        /// </summary>
+        BLOB_LONGBINARY = 0x04,
+        /// <summary>
+        /// This is unichar data with no ClassID associated with it.
+        /// </summary>
+        BLOB_UNICHAR = 0x05
+    }
+}

--- a/src/AdoNetCore.AseClient/Enum/BlobType.cs
+++ b/src/AdoNetCore.AseClient/Enum/BlobType.cs
@@ -23,10 +23,12 @@ namespace AdoNetCore.AseClient.Enum
         BLOB_LONGCHAR = 0x03,
         /// <summary>
         ///  This is long binary data and has no ClassID associated with it.
+        /// Appears in ribo as BLOB_VARBINARY
         /// </summary>
         BLOB_LONGBINARY = 0x04,
         /// <summary>
         /// This is unichar data with no ClassID associated with it.
+        /// Appears in ribo as BLOB_UTF16
         /// </summary>
         BLOB_UNICHAR = 0x05
     }

--- a/src/AdoNetCore.AseClient/Enum/SerializationType.cs
+++ b/src/AdoNetCore.AseClient/Enum/SerializationType.cs
@@ -1,0 +1,27 @@
+namespace AdoNetCore.AseClient.Enum
+{
+    public enum SerializationType : byte
+    {
+        //todo: figure out what these names might actually be
+        /// <summary>
+        /// Use the default serialization associated with the specified <see cref="BlobType"/>.
+        /// Allowed cases:
+        /// <see cref="BlobType.BLOB_LONGCHAR"/> -  Characters are in their native format, the character set of the data is the same as that of all other character data as negotiated on the connection during login.
+        /// <see cref="BlobType.BLOB_LONGBINARY"/> - Binary data in its normal form
+        /// <see cref="BlobType.BLOB_UNICHAR"/> - This is unichar data with normal UTF-16 encoding with byte-order identical to that of the client
+        /// </summary>
+        SER_DEFAULT = 0x00,
+        /// <summary>
+        /// Allowed cases:
+        /// <see cref="BlobType.BLOB_FULLY_QUALIFIED_CLASS_NAME"/> - Native Java Serialization
+        /// <see cref="BlobType.BLOB_INT32_CLASS_ID"/> - Native Java Serialization
+        /// <see cref="BlobType.BLOB_UNICHAR"/> - This is unichar data in its UTF-8 encoding.
+        /// </summary>
+        SER_SPECIAL1 = 0x01,
+        /// <summary>
+        /// Allowed cases:
+        /// <see cref="BlobType.BLOB_UNICHAR"/> - This is unichar data in SCSU (compressed) encoding
+        /// </summary>
+        SER_SPECIAL2 = 0x02
+    }
+}

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -79,7 +79,7 @@ namespace AdoNetCore.AseClient.Internal
                 UserType = TypeMap.GetTdsUserType(dbType)
             };
 
-            //fixup the FormatItem's BlobType for strings
+            //fixup the FormatItem's BlobType for strings and byte arrays
             if (format.DataType == TdsDataType.TDS_BLOB)
             {
                 switch (parameter.DbType)
@@ -87,7 +87,9 @@ namespace AdoNetCore.AseClient.Internal
                     case DbType.String:
                         format.BlobType = BlobType.BLOB_UNICHAR;
                         break;
-                    //todo: consider adding support for DbType.Binary
+                    case DbType.Binary:
+                        format.BlobType = BlobType.BLOB_LONGBINARY;
+                        break;
                 }
             }
             

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -75,9 +76,21 @@ namespace AdoNetCore.AseClient.Internal
                 IsNullable = parameter.IsNullable,
                 Length = length,
                 DataType = TypeMap.GetTdsDataType(dbType, parameter.SendableValue, length, parameter.ParameterName),
-                UserType = TypeMap.GetTdsUserType(dbType),
+                UserType = TypeMap.GetTdsUserType(dbType)
             };
 
+            //fixup the FormatItem's BlobType for strings
+            if (format.DataType == TdsDataType.TDS_BLOB)
+            {
+                switch (parameter.DbType)
+                {
+                    case DbType.String:
+                        format.BlobType = BlobType.BLOB_UNICHAR;
+                        break;
+                    //todo: consider adding support for DbType.Binary
+                }
+            }
+            
             //fixup the FormatItem's length,scale,precision for decimals
             if (format.IsDecimalType)
             {

--- a/src/AdoNetCore.AseClient/Internal/StreamReadExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/StreamReadExtensions.cs
@@ -137,6 +137,18 @@ namespace AdoNetCore.AseClient.Internal
             return stream.ReadByteArray(length);
         }
 
+        public static byte[] ReadNullableUShortLengthPrefixedByteArray(this Stream stream)
+        {
+            var length = stream.ReadUShort();
+
+            if (length == 0)
+            {
+                return null;
+            }
+
+            return stream.ReadByteArray(length);
+        }
+
         public static byte[] ReadNullableIntLengthPrefixedByteArray(this Stream stream)
         {
             var length = stream.ReadInt();

--- a/src/AdoNetCore.AseClient/Internal/StreamWriteExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/StreamWriteExtensions.cs
@@ -122,6 +122,14 @@ namespace AdoNetCore.AseClient.Internal
             stream.Write(value, 0, len);
         }
 
+        public static void WriteBlobSpecificIntPrefixedByteArray(this Stream stream, byte[] value)
+        {
+            var len = value.Length;
+            var endOfBlobLen = (uint) len | 0x80000000; //highest-order bit set means end of blob data
+            stream.WriteUInt(endOfBlobLen);
+            stream.Write(value, 0, len);
+        }
+
         public static void WriteIntPrefixedByteArray(this Stream stream, byte[] value)
         {
             var len = value.Length;

--- a/src/AdoNetCore.AseClient/Internal/StreamWriteExtensions.cs
+++ b/src/AdoNetCore.AseClient/Internal/StreamWriteExtensions.cs
@@ -109,6 +109,18 @@ namespace AdoNetCore.AseClient.Internal
             stream.WriteByte(len);
             stream.Write(value, 0, len);
         }
+        public static void WriteNullableUShortPrefixedByteArray(this Stream stream, byte[] value)
+        {
+            var len = (ushort)(value?.Length ?? 0);
+            stream.WriteUShort(len);
+
+            if (len == 0)
+            {
+                return;
+            }
+
+            stream.Write(value, 0, len);
+        }
 
         public static void WriteIntPrefixedByteArray(this Stream stream, byte[] value)
         {

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -9,6 +9,8 @@ namespace AdoNetCore.AseClient.Internal
     internal static class TypeMap
     {
         private const int VarLongBoundary = 255;
+        //Above this length, send strings as TDS_BLOBs
+        private const int StringAsBlobBoundary = 8192;
 
         private static readonly Dictionary<DbType, Func<object, int, TdsDataType>> DbToTdsMap = new Dictionary<DbType, Func<object, int, TdsDataType>>
         {
@@ -21,7 +23,7 @@ namespace AdoNetCore.AseClient.Internal
             {DbType.UInt32, (value, length) => value == DBNull.Value ? TdsDataType.TDS_UINTN : TdsDataType.TDS_UINT4},
             {DbType.Int64, (value, length) => value == DBNull.Value ? TdsDataType.TDS_INTN : TdsDataType.TDS_INT8},
             {DbType.UInt64, (value, length) => value == DBNull.Value ? TdsDataType.TDS_UINTN : TdsDataType.TDS_UINT8},
-            {DbType.String, (value, length) => TdsDataType.TDS_LONGBINARY},
+            {DbType.String, (value, length) => length <= StringAsBlobBoundary ? TdsDataType.TDS_LONGBINARY : TdsDataType.TDS_BLOB},
             {DbType.StringFixedLength, (value, length) => TdsDataType.TDS_LONGBINARY},
             {DbType.AnsiString, (value, length) => length <= VarLongBoundary ? TdsDataType.TDS_VARCHAR : TdsDataType.TDS_LONGCHAR},
             {DbType.AnsiStringFixedLength, (value, length) => length <= VarLongBoundary ? TdsDataType.TDS_VARCHAR : TdsDataType.TDS_LONGCHAR},

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -11,6 +11,7 @@ namespace AdoNetCore.AseClient.Internal
         private const int VarLongBoundary = 255;
         //Above this length, send strings as TDS_BLOBs
         private const int StringAsBlobBoundary = 8192;
+        private const int BinaryAsBlobBoundary = 16384;
 
         private static readonly Dictionary<DbType, Func<object, int, TdsDataType>> DbToTdsMap = new Dictionary<DbType, Func<object, int, TdsDataType>>
         {
@@ -27,7 +28,12 @@ namespace AdoNetCore.AseClient.Internal
             {DbType.StringFixedLength, (value, length) => TdsDataType.TDS_LONGBINARY},
             {DbType.AnsiString, (value, length) => length <= VarLongBoundary ? TdsDataType.TDS_VARCHAR : TdsDataType.TDS_LONGCHAR},
             {DbType.AnsiStringFixedLength, (value, length) => length <= VarLongBoundary ? TdsDataType.TDS_VARCHAR : TdsDataType.TDS_LONGCHAR},
-            {DbType.Binary, (value, length) => length <= VarLongBoundary ? TdsDataType.TDS_BINARY : TdsDataType.TDS_LONGBINARY},
+            {DbType.Binary, (value, length) =>
+                length <= BinaryAsBlobBoundary
+                    ? length <= VarLongBoundary
+                        ? TdsDataType.TDS_BINARY
+                        : TdsDataType.TDS_LONGBINARY
+                    : TdsDataType.TDS_BLOB},
             {DbType.Guid, (value, length) => TdsDataType.TDS_BINARY},
             {DbType.Decimal, (value, length) => TdsDataType.TDS_NUMN},
             {DbType.Currency, (value, length) => TdsDataType.TDS_MONEYN},

--- a/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
@@ -313,22 +313,7 @@ namespace AdoNetCore.AseClient.Internal
                 case string s:
                     stream.WriteByte((byte)SerializationType.SER_DEFAULT);
                     stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
-                    stream.WriteIntPrefixedByteArray(Encoding.Unicode.GetBytes(s));
-                    break;
-                case char c:
-                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
-                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
-                    stream.WriteIntPrefixedByteArray(Encoding.Unicode.GetBytes(new[] { c }));
-                    break;
-                case byte[] ba:
-                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
-                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
-                    stream.WriteIntPrefixedByteArray(ba);
-                    break;
-                case byte b:
-                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
-                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
-                    stream.WriteIntPrefixedByteArray(new[] { b });
+                    stream.WriteBlobSpecificIntPrefixedByteArray(Encoding.Unicode.GetBytes(s));
                     break;
                 default:
                     throw new AseException($"TDS_BLOB support for {value.GetType().Name} not yet implemented");

--- a/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
@@ -86,6 +86,7 @@ namespace AdoNetCore.AseClient.Internal
             { TdsDataType.TDS_VARBINARY, WriteTDS_VARBINARY },
             { TdsDataType.TDS_BINARY, WriteTDS_BINARY },
             { TdsDataType.TDS_LONGBINARY, WriteTDS_LONGBINARY },
+            { TdsDataType.TDS_BLOB, WriteTDS_BLOB },
             { TdsDataType.TDS_DECN, WriteTDS_DECN },
             { TdsDataType.TDS_NUMN, WriteTDS_NUMN },
             { TdsDataType.TDS_DATETIME, WriteTDS_DATETIME },
@@ -298,6 +299,39 @@ namespace AdoNetCore.AseClient.Internal
                         stream.WriteInt(0);
                         break;
                 }
+            }
+        }
+        private static void WriteTDS_BLOB(object value, Stream stream, FormatItem format, Encoding enc)
+        {
+            //byte serialization type
+            //short-prefixed class id
+            //n chunks of data
+            //    4-byte datalen (highest-order bit indicates if there are more chunks)
+            //    data
+            switch (value)
+            {
+                case string s:
+                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
+                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
+                    stream.WriteIntPrefixedByteArray(Encoding.Unicode.GetBytes(s));
+                    break;
+                case char c:
+                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
+                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
+                    stream.WriteIntPrefixedByteArray(Encoding.Unicode.GetBytes(new[] { c }));
+                    break;
+                case byte[] ba:
+                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
+                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
+                    stream.WriteIntPrefixedByteArray(ba);
+                    break;
+                case byte b:
+                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
+                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
+                    stream.WriteIntPrefixedByteArray(new[] { b });
+                    break;
+                default:
+                    throw new AseException($"TDS_BLOB support for {value.GetType().Name} not yet implemented");
             }
         }
 

--- a/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
@@ -315,6 +315,11 @@ namespace AdoNetCore.AseClient.Internal
                     stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
                     stream.WriteBlobSpecificIntPrefixedByteArray(Encoding.Unicode.GetBytes(s));
                     break;
+                case byte[] ba:
+                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
+                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
+                    stream.WriteBlobSpecificIntPrefixedByteArray(ba);
+                    break;
                 default:
                     throw new AseException($"TDS_BLOB support for {value.GetType().Name} not yet implemented");
             }

--- a/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
+++ b/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net46</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -23,13 +23,13 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <DefineConstants>$(DefineConstants);NET_FRAMEWORK</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp1.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'netcoreapp1.1' Or '$(TargetFramework)' == 'netcoreapp1.0'">
     <DefineConstants>$(DefineConstants);NET_CORE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net46'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2' Or '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'net46'">
     <DefineConstants>$(DefineConstants);ENABLE_DB_PROVIDERFACTORY</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/test/AdoNetCore.AseClient.Tests/Integration/Insert/BinaryTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Insert/BinaryTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using AdoNetCore.AseClient.Internal;
+using AdoNetCore.AseClient.Tests.ConnectionProvider;
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration.Insert
+{
+    [Category("basic")]
+#if NET_FRAMEWORK
+    [TestFixture(typeof(SapConnectionProvider), Explicit = true, Reason = "SAP AseClient tests are run for compatibility purposes.")]
+#endif
+    [TestFixture(typeof(CoreFxConnectionProvider))]
+    public class BinaryTests<T> where T : IConnectionProvider
+    {
+        private DbConnection GetConnection()
+        {
+            return Activator.CreateInstance<T>().GetConnection(ConnectionStrings.Pooled);
+        }
+
+        private const string SetUpSql = @"create table [dbo].[insert_image_tests] (image_field image null)";
+        private const string CleanUpSql = @"IF EXISTS(SELECT 1 FROM sysobjects WHERE name = 'insert_image_tests')
+BEGIN
+    drop table [dbo].[insert_image_tests]
+END";
+
+        [SetUp]
+        public void Setup()
+        {
+            Logger.Enable();
+
+            using (var connection = GetConnection())
+            {
+                connection.Execute(CleanUpSql);
+                connection.Execute(SetUpSql);
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Execute(CleanUpSql);
+            }
+        }
+
+        public static IEnumerable<TestCaseData> Insert_Parameter_Cases()
+        {
+            yield return new TestCaseData(1);
+            yield return new TestCaseData(10);
+            yield return new TestCaseData(100);
+            yield return new TestCaseData(127);
+            yield return new TestCaseData(1000);
+            yield return new TestCaseData(8192);
+            yield return new TestCaseData(8193);
+            yield return new TestCaseData(10000);
+            yield return new TestCaseData(16384);
+            yield return new TestCaseData(16385);
+            yield return new TestCaseData(100000);
+            yield return new TestCaseData(1000000);
+        }
+
+        [TestCaseSource(nameof(Insert_Parameter_Cases))]
+        public void Insert_Parameter_Dapper(int count)
+        {
+            var value = new byte[count];
+            using (var connection = GetConnection())
+            {
+                connection.Execute("set textsize 1000000");
+                var p = new DynamicParameters();
+                p.Add("@image_field", value, DbType.Binary);
+                connection.Execute("insert into [dbo].[insert_image_tests] (image_field) values (@image_field)", p);
+                var insertedLength = connection.QuerySingle<int>("select top 1 datalength(image_field) from [dbo].[insert_image_tests]");
+                Assert.AreEqual(value.Length, insertedLength);
+            }
+
+            Insert_Parameter_VerifyResult(GetConnection, "insert_image_tests", "image_field", value);
+        }
+
+        private void Insert_Parameter_VerifyResult(Func<DbConnection> getConnection, string table, string field, byte[] expected)
+        {
+            using (var connection = getConnection())
+            {
+                Assert.AreEqual(expected, connection.QuerySingle<byte[]>($"select top 1 {field} from [dbo].[{table}]"));
+            }
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/Insert/TextTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Insert/TextTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using AdoNetCore.AseClient.Tests.ConnectionProvider;
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration.Insert
+{
+    [Category("basic")]
+#if NET_FRAMEWORK
+    [TestFixture(typeof(SapConnectionProvider), Explicit = true, Reason = "SAP AseClient tests are run for compatibility purposes.")]
+#endif
+    [TestFixture(typeof(CoreFxConnectionProvider))]
+    public class TextTests<T> where T : IConnectionProvider
+    {
+        private DbConnection GetConnection()
+        {
+            return Activator.CreateInstance<T>().GetConnection(ConnectionStrings.Pooled);
+        }
+
+        private const string SetUpSql = @"create table [dbo].[insert_text_tests] (text_field text null)";
+        private const string CleanUpSql = @"IF EXISTS(SELECT 1 FROM sysobjects WHERE name = 'insert_text_tests')
+BEGIN
+    drop table [dbo].[insert_text_tests]
+END";
+
+        [SetUp]
+        public void Setup()
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Execute(CleanUpSql);
+                connection.Execute(SetUpSql);
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Execute(CleanUpSql);
+            }
+        }
+
+        public static IEnumerable<TestCaseData> Insert_Parameter_Cases()
+        {
+            yield return new TestCaseData(null);
+            yield return new TestCaseData(new string('1', 1));
+            yield return new TestCaseData(new string('1', 10));
+            yield return new TestCaseData(new string('1', 100));
+            yield return new TestCaseData(new string('1', 127));
+            yield return new TestCaseData(new string('1', 1000));
+            yield return new TestCaseData(new string('1', 8192));
+            yield return new TestCaseData(new string('1', 8193));
+            yield return new TestCaseData(new string('1', 10000));
+            yield return new TestCaseData(new string('1', 16384));
+            yield return new TestCaseData(new string('1', 16385));
+            yield return new TestCaseData(new string('1', 100000));
+            
+        }
+
+        [TestCaseSource(nameof(Insert_Parameter_Cases))]
+        public void Insert_Parameter_Dapper(string value)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Execute("set textsize 1000000");
+                var p = new DynamicParameters();
+                p.Add("@text_field", value, DbType.String);
+                connection.Execute("insert into [dbo].[insert_text_tests] (text_field) values (@text_field)", p);
+                var insertedLength = connection.QuerySingle<int?>("select top 1 len(text_field) from [dbo].[insert_text_tests]");
+                Assert.AreEqual(value?.Length ?? 0, insertedLength ?? 0);
+            }
+
+            Insert_Parameter_VerifyResult(GetConnection, "insert_text_tests", "text_field", value);
+        }
+
+        private void Insert_Parameter_VerifyResult(Func<DbConnection> getConnection, string table, string field, string expected)
+        {
+            using (var connection = getConnection())
+            {
+                Assert.AreEqual(expected, connection.QuerySingle<string>($"select top 1 {field} from [dbo].[{table}]"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allows the user to send large (>8192 chars/16384 bytes) string parameters.

It might be good to extend this to support byte arrays as well, will need to investigate if the reference driver supports this