### PR TITLE
Add support for TDS_ROWFMT

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/TokenReader.cs
+++ b/src/AdoNetCore.AseClient/Internal/TokenReader.cs
@@ -62,6 +62,7 @@ namespace AdoNetCore.AseClient.Internal
             {TokenType.TDS_RETURNSTATUS, ReturnStatusToken.Create },
             {TokenType.TDS_DONEINPROC, DoneInProcToken.Create },
             {TokenType.TDS_DONEPROC, DoneProcToken.Create },
+            {TokenType.TDS_ROWFMT, RowFormatToken.Create },
             {TokenType.TDS_ROWFMT2, RowFormat2Token.Create },
             {TokenType.TDS_CONTROL, ControlToken.Create },
             {TokenType.TDS_ROW, RowToken.Create },

--- a/src/AdoNetCore.AseClient/Token/RowFormatToken.cs
+++ b/src/AdoNetCore.AseClient/Token/RowFormatToken.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using AdoNetCore.AseClient.Enum;
+using AdoNetCore.AseClient.Interface;
+using AdoNetCore.AseClient.Internal;
+
+namespace AdoNetCore.AseClient.Token
+{
+    internal class RowFormatToken : IFormatToken
+    {
+        public TokenType Type => TokenType.TDS_ROWFMT;
+
+        public void Write(Stream stream, DbEnvironment env)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Read(Stream stream, DbEnvironment env, IFormatToken previousFormatToken)
+        {
+            Logger.Instance?.WriteLine($"<- {Type}");
+            var remainingLength = stream.ReadUShort();
+            using (var ts = new ReadablePartialStream(stream, remainingLength))
+            {
+                var formats = new List<FormatItem>();
+                var columnCount = ts.ReadUShort();
+
+                for (var i = 0; i < columnCount; i++)
+                {
+                    formats.Add(FormatItem.ReadForRow(ts, env.Encoding, Type));
+                }
+
+                Formats = formats.ToArray();
+            }
+        }
+
+        public static RowFormatToken Create(Stream stream, DbEnvironment env, IFormatToken previous)
+        {
+            var t = new RowFormatToken();
+            t.Read(stream, env, previous);
+            return t;
+        }
+
+        public FormatItem[] Formats { get; set; }
+    }
+}


### PR DESCRIPTION
The current implementation supports TDS_ROWFMT2 formatting token only. But ignoring TDS_ROWFMT token results in having null format reference. And reading the next row with null format reference results in throwing the exception _"Object reference not set to an instance of an object."_

In my particular case, the crash happened while getting **sp_loginconfig** stored procedure result from Sybase ACE 15.5. After adding support for TDS_ROWFMT token I was able to read that stored procedure result without a problem.