### PR TITLE
Setting the network stream read timeout based on parameters LoginTimeout

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -170,6 +170,8 @@ namespace AdoNetCore.AseClient.Internal
         {
             var environment = new DbEnvironment();
             var reader = new TokenReader();
+            // Setting the stream read timeout in milliseconds
+            networkStream.ReadTimeout = _parameters.LoginTimeout * 1000;
 
 #if ENABLE_ARRAY_POOL
             return new InternalConnection(_parameters, networkStream, reader, environment, _arrayPool);


### PR DESCRIPTION
Currently, network stream read timeout is -1 which means unlimited. That makes an application hang or freeze because of the driver if the server does not respond. In my particular case, it happened while connecting to some corrupted Sybase 16.0 installation under solaris platform. Maybe somebody knowing the driver code in more details can suggest some better solution for this problem. But the suggested simple modification makes the driver behaviour more natural resulting in AseException : "Pool timed out trying to reserve a connection" instead of keeping the application frozen forever.