### PR TITLE
Fixed support for outbound parameters for decimal and numeric types.

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -95,11 +95,17 @@ namespace AdoNetCore.AseClient.Internal
                         break;
                 }
             }
-            
+
             //fixup the FormatItem's length,scale,precision for decimals
             if (format.IsDecimalType)
             {
-                if (parameter.SendableValue == DBNull.Value)
+                if (parameter.IsOutput)
+                {
+                    format.Precision = parameter.Precision;
+                    format.Scale = parameter.Scale;
+                    format.Length = 1;
+                }
+                else if (parameter.SendableValue == DBNull.Value)
                 {
                     format.Precision = 1;
                     format.Scale = 0;

--- a/test/AdoNetCore.AseClient.Tests/Integration/OutboundParamProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/OutboundParamProcedureTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Data;
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration
+{
+    [TestFixture]
+    [Category("basic")]
+    public class OutboundParamProcedureTests
+    {
+        private readonly string _createProc = @"CREATE PROCEDURE dbo.sp_test_173(@TotalValue numeric(18,4) = 0 output)
+AS
+set @TotalValue = 2819.0444";
+        private readonly string _dropProc = @"drop procedure [dbo].[sp_test_173]";
+
+        [SetUp]
+        public void Setup()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Execute(_createProc);
+            }
+        }
+
+        [Test]
+        public void Simple_Procedure_ShouldExecute()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Open();
+                var cmd = connection.CreateCommand();
+                cmd.CommandText = "sp_test_175";
+                cmd.CommandType = CommandType.StoredProcedure;
+                var total = new AseParameter()
+                {
+                    ParameterName = "@TotalValue",
+                    AseDbType = AseDbType.Decimal,
+                    Direction = ParameterDirection.Output,
+                    Precision = 18,
+                    Scale = 4
+                };
+                cmd.Parameters.Add(total);
+                var result = cmd.ExecuteNonQuery();
+                Assert.AreEqual(2819.0444m,Convert.ToDecimal(total.SendableValue));
+            }
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Execute(_dropProc);
+            }
+        }
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/OutboundParamProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/OutboundParamProcedureTests.cs
@@ -30,7 +30,7 @@ set @TotalValue = 2819.0444";
             {
                 connection.Open();
                 var cmd = connection.CreateCommand();
-                cmd.CommandText = "sp_test_175";
+                cmd.CommandText = "sp_test_173";
                 cmd.CommandType = CommandType.StoredProcedure;
                 var total = new AseParameter()
                 {

--- a/test/AdoNetCore.AseClient.Tests/Integration/Query/NumericTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Query/NumericTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using AdoNetCore.AseClient.Tests.ConnectionProvider;
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration.Query
+{
+    [Category("basic")]
+#if NET_FRAMEWORK
+    [TestFixture(typeof(SapConnectionProvider), Explicit = true, Reason = "SAP AseClient tests are run for compatibility purposes.")]
+#endif
+    [TestFixture(typeof(CoreFxConnectionProvider))]
+    public class NumericTests<T> where T : IConnectionProvider
+    {
+        private DbConnection GetConnection()
+        {
+            return Activator.CreateInstance<T>().GetConnection(ConnectionStrings.PooledUtf8);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Execute("create table [dbo].[decimal_test_table] (value decimal(18,4))");
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Execute("drop table [dbo].[decimal_test_table]");
+            }
+        }
+
+        public static IEnumerable<TestCaseData> SelectNumeric_FromTable_Cases()
+        {
+            yield return new TestCaseData(1m);
+            yield return new TestCaseData(2819.0444m);
+            yield return new TestCaseData(12345678901234.9999m);
+            yield return new TestCaseData(-12345678901234.9999m);
+        }
+
+        [TestCaseSource(nameof(SelectNumeric_FromTable_Cases))]
+        public void SelectNumeric_FromTable(decimal input)
+        {
+            using (var connection = GetConnection())
+            {
+                var p = new DynamicParameters();
+                p.Add("@input", input, DbType.Decimal);
+                connection.Execute("insert into [dbo].[decimal_test_table] (value) values (@input)", p);
+            }
+
+            using (var connection = GetConnection())
+            {
+                Assert.AreEqual(input, connection.QuerySingle<decimal>("select top 1 value from [dbo].[decimal_test_table]"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #173 