### PR TITLE
improve x509 related code

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/PemParser.cs
+++ b/src/AdoNetCore.AseClient/Internal/PemParser.cs
@@ -11,7 +11,7 @@ namespace AdoNetCore.AseClient.Internal
             "(?<certificate>(-----BEGIN CERTIFICATE-----)(.|\r\n|\r|\n)+?(-----END CERTIFICATE-----))",
             RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Multiline);
 
-        public IEnumerable<X509Certificate> ParseCertificates(string data)
+        public IEnumerable<X509Certificate2> ParseCertificates(string data)
         {
             var matches = CertificateRegex.Matches(data);
 
@@ -24,9 +24,9 @@ namespace AdoNetCore.AseClient.Internal
                 }
             }
         }
-        public X509Certificate ParseCertificate(string data)
+        public X509Certificate2 ParseCertificate(string data)
         {
-            return new X509Certificate(Encoding.ASCII.GetBytes(data));
+            return new X509Certificate2(Encoding.ASCII.GetBytes(data));
         }
     }
 }


### PR DESCRIPTION
fixes? #166 

The existing code appears to fail for us if we generate a self signed chain of certs, When debugging I noted that the x509 chain had an error of `PartialChain` and set about fixing that...

This change brings the driver closer in line with the official driver, though it doesn't match exactly still (in testing, the official driver doesn't catch a number of binary changes that can be made to the trusted file and I don't see how the official driver accepts the CA provided by the OS).

These changes could be breaking for anyone out there who happens to be using an invalid cert for their trusted root due to validating the thumbprint instead of the name and serial number.
