### PR TITLE
Address issues 182,183, 185, 186, 187

### DIFF
--- a/AdoNetCore.AseClient.sln
+++ b/AdoNetCore.AseClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdoNetCore.AseClient", "src\AdoNetCore.AseClient\AdoNetCore.AseClient.csproj", "{A994B1E4-2B7F-40B8-B045-57E4F324FF67}"
 EndProject

--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
@@ -6,7 +6,4 @@
 <PropertyGroup>
    <LangVersion>7</LangVersion>
 </PropertyGroup>
-<ItemGroup>
-  <Compile Remove="Internal\UserTypeMetadata.cs" />
-</ItemGroup>  
 </Project>

--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
@@ -3,4 +3,10 @@
   <PropertyGroup>
     <Description>.NET Core data provider for Sybase ASE</Description>
   </PropertyGroup>
+<PropertyGroup>
+   <LangVersion>7</LangVersion>
+</PropertyGroup>
+<ItemGroup>
+  <Compile Remove="Internal\UserTypeMetadata.cs" />
+</ItemGroup>  
 </Project>

--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj.DotSettings
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String></wpf:ResourceDictionary>

--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj.DotSettings
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String></wpf:ResourceDictionary>

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.IO;
@@ -28,7 +27,7 @@ namespace AdoNetCore.AseClient
         private string _commandText;
         private UpdateRowSource _updatedRowSource;
         private bool? _namedParameters;
-        internal readonly IDictionary<string, FormatItem> FormatItems;
+        internal FormatItem FormatItem { get; set; }
 
         /// <summary>
         /// Constructor function for an <see cref="AseCommand"/> instance.
@@ -37,7 +36,6 @@ namespace AdoNetCore.AseClient
         public AseCommand()
         {
             AseParameters = new AseParameterCollection();
-            FormatItems = new Dictionary<string, FormatItem>();
         }
 
         /// <summary>

--- a/src/AdoNetCore.AseClient/AseCommand.cs
+++ b/src/AdoNetCore.AseClient/AseCommand.cs
@@ -113,33 +113,11 @@ namespace AdoNetCore.AseClient
             return new AseParameter();
         }
 
-        public AseParameter CreateParameter(string name, object value, DbType dbType, int? overrideUserType)
-        {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(AseCommand));
-            }
-            return new AseParameter(name, value, dbType, overrideUserType);
-        }
-
         protected override DbParameter CreateDbParameter()
         {
             return CreateParameter();
         }
 
-        //command.SetParameter("@psComment", comment, DbType.String, 36);
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="parameterName"></param>
-        /// <param name="parameterValue"></param>
-        /// <param name="dbType"></param>
-        /// <param name="overrideUserType"></param>
-        /// <returns></returns>
-        public AseParameter CreateParameter(string parameterName, string parameterValue, DbType dbType, int? overrideUserType)
-        {
-            return new AseParameter(parameterName, parameterValue, dbType, overrideUserType);
-        }
 
         /// <summary>
         /// Executes a Transact-SQL statement against the connection and returns the number of rows affected.

--- a/src/AdoNetCore.AseClient/AseCommandBuilder.cs
+++ b/src/AdoNetCore.AseClient/AseCommandBuilder.cs
@@ -1,4 +1,4 @@
-﻿#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
+#if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/AdoNetCore.AseClient/AseDataReader.cs
+++ b/src/AdoNetCore.AseClient/AseDataReader.cs
@@ -64,19 +64,16 @@ namespace AdoNetCore.AseClient
             _results.CompleteAdding();
         }
 
-        /// <inheritdoc />
         public override bool GetBoolean(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToBoolean(provider));
         }
 
-        /// <inheritdoc />
         public override byte GetByte(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToByte(provider));
         }
 
-        /// <inheritdoc />
         public override long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferOffset, int length)
         {
             if (IsDBNull(i))
@@ -140,13 +137,11 @@ namespace AdoNetCore.AseClient
             return bytesToRead;
         }
 
-        /// <inheritdoc />
         public override char GetChar(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToChar(provider));
         }
 
-        /// <inheritdoc />
         public override long GetChars(int i, long fieldOffset, char[] buffer, int bufferOffset, int length)
         {
             if (IsDBNull(i))
@@ -209,7 +204,6 @@ namespace AdoNetCore.AseClient
             return charsToRead;
         }
 
-        /// <inheritdoc />
         public override string GetDataTypeName(int ordinal)
         {
             if (_currentTable  == null || ordinal < 0)
@@ -225,13 +219,11 @@ namespace AdoNetCore.AseClient
             return _currentTable .Formats[ordinal].GetDataTypeName();
         }
 
-        /// <inheritdoc />
         public override IEnumerator GetEnumerator()
         {
             return new AseDataReaderEnumerator(this);
         }
 
-        /// <inheritdoc />
         public override DateTime GetDateTime(int i)
         {
             var obj = GetNonNullValue(i);
@@ -264,19 +256,16 @@ namespace AdoNetCore.AseClient
             }
         }
 
-        /// <inheritdoc />
         public override decimal GetDecimal(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToDecimal(provider));
         }
 
-        /// <inheritdoc />
         public override double GetDouble(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToDouble(provider));
         }
 
-        /// <inheritdoc />
         public override Type GetFieldType(int i)
         {
             var format = GetFormat(i);
@@ -285,13 +274,11 @@ namespace AdoNetCore.AseClient
                 : TypeMap.GetNetType(format, true);
         }
 
-        /// <inheritdoc />
         public override float GetFloat(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToSingle(provider));
         }
 
-        /// <inheritdoc />
         public override Guid GetGuid(int i)
         {
             if (IsDBNull(i))
@@ -366,7 +353,6 @@ namespace AdoNetCore.AseClient
             throw new InvalidCastException($"Cannot convert from {GetFieldType(i)} to {nameof(T)}");
         }
 
-        /// <inheritdoc />
         public override string GetString(int i)
         {
             var obj = GetNonNullValue(i);
@@ -394,7 +380,6 @@ namespace AdoNetCore.AseClient
         //    throw new NotImplementedException();
         //}
 
-        /// <inheritdoc />
         public override string GetName(int i)
         {
             var format = GetFormat(i);
@@ -406,7 +391,6 @@ namespace AdoNetCore.AseClient
             return format.DisplayColumnName;
         }
 
-        /// <inheritdoc />
         public override int GetOrdinal(string name)
         {
             if (string.IsNullOrEmpty(name))
@@ -436,7 +420,6 @@ namespace AdoNetCore.AseClient
             throw new ArgumentException();
         }
 
-        /// <inheritdoc />
         public override object GetValue(int i)
         {
             if (!ValueExists(i))
@@ -461,7 +444,6 @@ namespace AdoNetCore.AseClient
             return obj;
         }
 
-        /// <inheritdoc />
         public override int GetValues(object[] values)
         {
             var num = values.Length;
@@ -486,7 +468,6 @@ namespace AdoNetCore.AseClient
             return num;
         }
 
-        /// <inheritdoc />
         public override bool IsDBNull(int i)
         {
             if (!ValueExists(i))
@@ -497,19 +478,14 @@ namespace AdoNetCore.AseClient
             return CurrentRow.Items[i] == DBNull.Value;
         }
 
-        /// <inheritdoc />
         public override int FieldCount => _currentTable?.Formats?.Length ?? 0;
 
-        /// <inheritdoc />
         public override int VisibleFieldCount => FieldCount;
 
-        /// <inheritdoc />
         public override bool HasRows => CurrentRowCount > 0;
 
-        /// <inheritdoc />
         public override object this[int ordinal] => GetValue(ordinal);
 
-        /// <inheritdoc />
         public override object this[string name] => GetValue(GetOrdinal(name));
 
         public
@@ -538,7 +514,6 @@ namespace AdoNetCore.AseClient
         }
 
 #if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
-        /// <inheritdoc />
         public override DataTable GetSchemaTable()
         {
             EnsureSchemaTable();
@@ -661,14 +636,11 @@ namespace AdoNetCore.AseClient
             return false;
         }
 
-        /// <inheritdoc />
         public override int Depth => 0;
 
-        /// <inheritdoc />
         public override bool IsClosed => _currentTable == null;
         private int _finalRecordsAffected = -1;
 
-        /// <inheritdoc />
         public override int RecordsAffected => _currentTable != null && _currentResult < _totalResults ? _currentTable.RecordsAffected : _finalRecordsAffected;
 
         public void SetRecordsAffected(int value)

--- a/src/AdoNetCore.AseClient/AseDataReader.cs
+++ b/src/AdoNetCore.AseClient/AseDataReader.cs
@@ -10,6 +10,9 @@ using AdoNetCore.AseClient.Internal;
 
 namespace AdoNetCore.AseClient
 {
+    /// <summary>
+    /// ASE implementation of <see cref="IDataReader"/>
+    /// </summary>
     public sealed class AseDataReader : DbDataReader
     {
         private TableResult _currentTable;
@@ -61,16 +64,19 @@ namespace AdoNetCore.AseClient
             _results.CompleteAdding();
         }
 
+        /// <inheritdoc />
         public override bool GetBoolean(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToBoolean(provider));
         }
 
+        /// <inheritdoc />
         public override byte GetByte(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToByte(provider));
         }
 
+        /// <inheritdoc />
         public override long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferOffset, int length)
         {
             if (IsDBNull(i))
@@ -134,11 +140,13 @@ namespace AdoNetCore.AseClient
             return bytesToRead;
         }
 
+        /// <inheritdoc />
         public override char GetChar(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToChar(provider));
         }
 
+        /// <inheritdoc />
         public override long GetChars(int i, long fieldOffset, char[] buffer, int bufferOffset, int length)
         {
             if (IsDBNull(i))
@@ -201,6 +209,7 @@ namespace AdoNetCore.AseClient
             return charsToRead;
         }
 
+        /// <inheritdoc />
         public override string GetDataTypeName(int ordinal)
         {
             if (_currentTable  == null || ordinal < 0)
@@ -216,11 +225,13 @@ namespace AdoNetCore.AseClient
             return _currentTable .Formats[ordinal].GetDataTypeName();
         }
 
+        /// <inheritdoc />
         public override IEnumerator GetEnumerator()
         {
             return new AseDataReaderEnumerator(this);
         }
 
+        /// <inheritdoc />
         public override DateTime GetDateTime(int i)
         {
             var obj = GetNonNullValue(i);
@@ -253,16 +264,19 @@ namespace AdoNetCore.AseClient
             }
         }
 
+        /// <inheritdoc />
         public override decimal GetDecimal(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToDecimal(provider));
         }
 
+        /// <inheritdoc />
         public override double GetDouble(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToDouble(provider));
         }
 
+        /// <inheritdoc />
         public override Type GetFieldType(int i)
         {
             var format = GetFormat(i);
@@ -271,11 +285,13 @@ namespace AdoNetCore.AseClient
                 : TypeMap.GetNetType(format, true);
         }
 
+        /// <inheritdoc />
         public override float GetFloat(int i)
         {
             return GetPrimitive(i, (value, provider) => value.ToSingle(provider));
         }
 
+        /// <inheritdoc />
         public override Guid GetGuid(int i)
         {
             if (IsDBNull(i))
@@ -350,6 +366,7 @@ namespace AdoNetCore.AseClient
             throw new InvalidCastException($"Cannot convert from {GetFieldType(i)} to {nameof(T)}");
         }
 
+        /// <inheritdoc />
         public override string GetString(int i)
         {
             var obj = GetNonNullValue(i);
@@ -377,6 +394,7 @@ namespace AdoNetCore.AseClient
         //    throw new NotImplementedException();
         //}
 
+        /// <inheritdoc />
         public override string GetName(int i)
         {
             var format = GetFormat(i);
@@ -388,6 +406,7 @@ namespace AdoNetCore.AseClient
             return format.DisplayColumnName;
         }
 
+        /// <inheritdoc />
         public override int GetOrdinal(string name)
         {
             if (string.IsNullOrEmpty(name))
@@ -417,6 +436,7 @@ namespace AdoNetCore.AseClient
             throw new ArgumentException();
         }
 
+        /// <inheritdoc />
         public override object GetValue(int i)
         {
             if (!ValueExists(i))
@@ -441,6 +461,7 @@ namespace AdoNetCore.AseClient
             return obj;
         }
 
+        /// <inheritdoc />
         public override int GetValues(object[] values)
         {
             var num = values.Length;
@@ -465,6 +486,7 @@ namespace AdoNetCore.AseClient
             return num;
         }
 
+        /// <inheritdoc />
         public override bool IsDBNull(int i)
         {
             if (!ValueExists(i))
@@ -475,14 +497,19 @@ namespace AdoNetCore.AseClient
             return CurrentRow.Items[i] == DBNull.Value;
         }
 
+        /// <inheritdoc />
         public override int FieldCount => _currentTable?.Formats?.Length ?? 0;
 
+        /// <inheritdoc />
         public override int VisibleFieldCount => FieldCount;
 
+        /// <inheritdoc />
         public override bool HasRows => CurrentRowCount > 0;
 
+        /// <inheritdoc />
         public override object this[int ordinal] => GetValue(ordinal);
 
+        /// <inheritdoc />
         public override object this[string name] => GetValue(GetOrdinal(name));
 
         public
@@ -511,6 +538,7 @@ namespace AdoNetCore.AseClient
         }
 
 #if ENABLE_SYSTEM_DATA_COMMON_EXTENSIONS
+        /// <inheritdoc />
         public override DataTable GetSchemaTable()
         {
             EnsureSchemaTable();
@@ -633,16 +661,15 @@ namespace AdoNetCore.AseClient
             return false;
         }
 
+        /// <inheritdoc />
         public override int Depth => 0;
+
+        /// <inheritdoc />
         public override bool IsClosed => _currentTable == null;
         private int _finalRecordsAffected = -1;
-        public override int RecordsAffected
-        {
-            get
-            {
-                return _currentTable != null && _currentResult < _totalResults ? _currentTable.RecordsAffected : _finalRecordsAffected;
-            }
-        }
+
+        /// <inheritdoc />
+        public override int RecordsAffected => _currentTable != null && _currentResult < _totalResults ? _currentTable.RecordsAffected : _finalRecordsAffected;
 
         public void SetRecordsAffected(int value)
         {

--- a/src/AdoNetCore.AseClient/AseErrorCollection.cs
+++ b/src/AdoNetCore.AseClient/AseErrorCollection.cs
@@ -64,8 +64,8 @@ namespace AdoNetCore.AseClient
             var result = 0;
             for (var i = 1; i < errors.Length; i++)
             {
-                // The '=' in '<=' means that for equal severity, we take the last error in the list. 
-                if (errors[result].Severity <= errors[i].Severity)
+                // We will respect the order if they're the same and already sorted and only care for the different ones
+                if (errors[result].Severity < errors[i].Severity)
                 {
                     result = i;
                 }

--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -277,6 +277,12 @@ namespace AdoNetCore.AseClient
             Value = value;
         }
 
+        public AseParameter(string parameterName, object value, DbType dbType, int? overrideUserType) : this(parameterName, value)
+        {
+            DbType = dbType;
+            OverrideUserType = overrideUserType;
+        }
+
         public override void ResetDbType()
         {
             DbType = default(DbType);
@@ -470,5 +476,6 @@ namespace AdoNetCore.AseClient
         }
 #endif
         internal object SendableValue => Value.AsSendableValue(_type);
+        internal int? OverrideUserType { get; set; }
     }
 }

--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -276,13 +276,6 @@ namespace AdoNetCore.AseClient
             SourceVersion = sourceVersion;
             Value = value;
         }
-
-        public AseParameter(string parameterName, object value, DbType dbType, int? overrideUserType) : this(parameterName, value)
-        {
-            DbType = dbType;
-            OverrideUserType = overrideUserType;
-        }
-
         public override void ResetDbType()
         {
             DbType = default(DbType);
@@ -476,6 +469,6 @@ namespace AdoNetCore.AseClient
         }
 #endif
         internal object SendableValue => Value.AsSendableValue(_type);
-        internal int? OverrideUserType { get; set; }
+        //internal int? OverrideUserType { get; set; }
     }
 }

--- a/src/AdoNetCore.AseClient/AseParameter.cs
+++ b/src/AdoNetCore.AseClient/AseParameter.cs
@@ -469,6 +469,5 @@ namespace AdoNetCore.AseClient
         }
 #endif
         internal object SendableValue => Value.AsSendableValue(_type);
-        //internal int? OverrideUserType { get; set; }
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -156,6 +156,7 @@ namespace AdoNetCore.AseClient.Internal
                 default:
                     throw new ArgumentException($"Unexpected token type: {srcTokenType}.", nameof(srcTokenType));
             }
+
             ReadTypeInfo(format, stream, enc);
 
             Logger.Instance?.WriteLine($"  <- {format.ColumnName}: {format.DataType} (len: {format.Length}) (ut:{format.UserType}) (status:{format.RowStatus}) (loc:{format.LocaleInfo}) format names available: ColumnLabel [{format.ColumnLabel}], ColumnName [{format.ColumnName}], CatalogName [{format.CatalogName}], ParameterName [{format.ParameterName}], SchemaName [{format.SchemaName}], TableName [{format.TableName}]");
@@ -488,5 +489,15 @@ namespace AdoNetCore.AseClient.Internal
                     return string.Empty;
             }
         }
+
+        public bool IsKey() => (RowStatus & RowFormatItemStatus.TDS_ROW_KEY) == RowFormatItemStatus.TDS_ROW_KEY;
+
+        public bool IsIdentity() => (RowStatus & RowFormatItemStatus.TDS_ROW_IDENTITY) == RowFormatItemStatus.TDS_ROW_IDENTITY;
+
+        public bool IsUnique()
+        {
+            return (DataType == TdsDataType.TDS_VARBINARY || DataType == TdsDataType.TDS_BINARY) && UserType == 80 || IsIdentity();
+        }
+
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -63,7 +63,7 @@ namespace AdoNetCore.AseClient.Internal
         /// </summary>
         public SerializationType SerializationType { get; set; }
 
-        public static FormatItem CreateForParameter(AseParameter parameter, DbEnvironment env, CommandType commandType = CommandType.StoredProcedure)
+        public static FormatItem CreateForParameter(AseParameter parameter, DbEnvironment env, CommandType commandType)
         {
             parameter.AseDbType = TypeMap.InferType(parameter);
 
@@ -93,6 +93,7 @@ namespace AdoNetCore.AseClient.Internal
                         format.BlobType = BlobType.BLOB_UNICHAR;
                         if (commandType != CommandType.StoredProcedure)
                             format.UserType = 0;
+
                         break;
                     case DbType.Binary:
                         format.BlobType = BlobType.BLOB_LONGBINARY;

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -79,9 +79,7 @@ namespace AdoNetCore.AseClient.Internal
                 IsNullable = parameter.IsNullable,
                 Length = length,
                 DataType = TypeMap.GetTdsDataType(dbType, parameter.SendableValue, length, parameter.ParameterName),
-                //UserType = parameter.OverrideUserType ?? TypeMap.GetTdsUserType(dbType) // TypeMap.GetUserType(dbType, parameter.SendableValue, length)
-                UserType = parameter.OverrideUserType ?? TypeMap.GetUserType(dbType, parameter.SendableValue, length)
-                //UserType = TypeMap.GetUserType(dbType, parameter.SendableValue, length)
+                UserType = TypeMap.GetUserType(dbType, parameter.SendableValue, length)
             };
 
             //fixup the FormatItem's BlobType for strings and byte arrays

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -70,7 +70,6 @@ namespace AdoNetCore.AseClient.Internal
             var dbType = parameter.DbType;
 
             var length = TypeMap.GetFormatLength(dbType, parameter, env.Encoding);
-            Logger.Instance?.WriteLine($"TypeMap.GetFormatLength =>  {length}");
 
             var format = new FormatItem
             {

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -91,6 +91,12 @@ namespace AdoNetCore.AseClient.Internal
                         break;
                     case DbType.String:
                         format.BlobType = BlobType.BLOB_UNICHAR;
+                        // This is far less than ideal but at the time of addressing this issue whereby if the
+                        // BlobType is a BLOB_UNICHAR then the UserType would need to be 36 when it
+                        // is a stored proc otherwise it would need to be zero (0).
+                        //
+                        // In the future, we'd need to overhaul how TDS_BLOB is structured especially
+                        // around BLOB_UNICHAR and the UserType that it should return in a more consistent way
                         if (commandType != CommandType.StoredProcedure)
                             format.UserType = 0;
 

--- a/src/AdoNetCore.AseClient/Internal/Handler/ResponseParameterTokenHandler.cs
+++ b/src/AdoNetCore.AseClient/Internal/Handler/ResponseParameterTokenHandler.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Token;
@@ -30,14 +31,12 @@ namespace AdoNetCore.AseClient.Internal.Handler
             switch (token)
             {
                 case ReturnStatusToken t:
-                    foreach (AseParameter parameter in _parameters)
+                    foreach (var parameter in _parameters.OfType<AseParameter>().Where(p => p.Direction == ParameterDirection.ReturnValue))
                     {
-                        if (parameter.Direction == ParameterDirection.ReturnValue)
-                        {
-                            parameter.Value = t.Status;
-                        }
+                        parameter.Value = t.Status;
                     }
                     break;
+
                 case ParametersToken t:
                     var dict = new Dictionary<string, ParametersToken.Parameter>();
 
@@ -46,12 +45,9 @@ namespace AdoNetCore.AseClient.Internal.Handler
                         dict[p.Format.ParameterName] = p;
                     }
 
-                    foreach (AseParameter parameter in _parameters)
+                    foreach (var parameter in _parameters.OfType<AseParameter>().Where(p => p.IsOutput && dict.ContainsKey(p.ParameterName)))
                     {
-                        if (parameter.IsOutput && dict.ContainsKey(parameter.ParameterName))
-                        {
-                            parameter.Value = dict[parameter.ParameterName].Value;
-                        }
+                        parameter.Value = dict[parameter.ParameterName].Value;
                     }
                     break;
                 default:

--- a/src/AdoNetCore.AseClient/Internal/Handler/ResponseParameterTokenHandler.cs
+++ b/src/AdoNetCore.AseClient/Internal/Handler/ResponseParameterTokenHandler.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Token;
@@ -31,9 +30,10 @@ namespace AdoNetCore.AseClient.Internal.Handler
             switch (token)
             {
                 case ReturnStatusToken t:
-                    foreach (var parameter in _parameters.OfType<AseParameter>().Where(p => p.Direction == ParameterDirection.ReturnValue))
+                    foreach (AseParameter parameter in _parameters)
                     {
-                        parameter.Value = t.Status;
+                        if (parameter.Direction == ParameterDirection.ReturnValue)
+                            parameter.Value = t.Status;
                     }
                     break;
 
@@ -45,9 +45,10 @@ namespace AdoNetCore.AseClient.Internal.Handler
                         dict[p.Format.ParameterName] = p;
                     }
 
-                    foreach (var parameter in _parameters.OfType<AseParameter>().Where(p => p.IsOutput && dict.ContainsKey(p.ParameterName)))
+                    foreach (AseParameter parameter in _parameters)
                     {
-                        parameter.Value = dict[parameter.ParameterName].Value;
+                        if (parameter.IsOutput && dict.ContainsKey(parameter.ParameterName))
+                            parameter.Value = dict[parameter.ParameterName].Value;
                     }
                     break;
                 default:

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -706,45 +706,6 @@ SET FMTONLY OFF";
             };
         }
 
-        //private IToken[] BuildParameterTokens(AseParameterCollection parameters, bool includeUserType = true)
-        //{
-        //    var formatItems = new List<FormatItem>();
-        //    var parameterItems = new List<ParametersToken.Parameter>();
-
-        //    foreach (var parameter in parameters.SendableParameters)
-        //    {
-
-        //        var formatItem = FormatItem.CreateForParameter(parameter, _environment);
-
-        //        //if (!includeUserType)
-        //        //    formatItem.UserType = 0;
-
-        //        formatItems.Add(formatItem);
-        //        parameterItems.Add(new ParametersToken.Parameter
-        //        {
-        //            Format = formatItem,
-        //            Value = parameter.SendableValue
-        //        });
-        //    }
-
-        //    if (formatItems.Count == 0)
-        //    {
-        //        return new IToken[0];
-        //    }
-
-        //    return new IToken[]
-        //    {
-        //        new ParameterFormat2Token
-        //        {
-        //            Formats = formatItems.ToArray()
-        //        },
-        //        new ParametersToken
-        //        {
-        //            Parameters = parameterItems.ToArray()
-        //        }
-        //    };
-        //}
-
         public void Dispose()
         {
             if (IsDisposed)

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -670,16 +670,15 @@ SET FMTONLY OFF";
             foreach (var parameter in command.Parameters.SendableParameters)
             {
                 var parameterName = parameter.ParameterName ?? command.Parameters.IndexOf(parameter).ToString();
-                if (!command.FormatItems.TryGetValue(parameterName, out FormatItem formatItem))
+                if (command.FormatItem == null || command.FormatItem.ParameterName != parameterName)
                 {
-                    formatItem = FormatItem.CreateForParameter(parameter, _environment, command.CommandType);
-                    command.FormatItems.Add(parameterName, formatItem);
+                    command.FormatItem = FormatItem.CreateForParameter(parameter, _environment, command.CommandType);
                 }
 
-                formatItems.Add(formatItem);
+                formatItems.Add(command.FormatItem);
                 parameterItems.Add(new ParametersToken.Parameter
                 {
-                    Format = formatItem,
+                    Format = command.FormatItem,
                     Value = parameter.SendableValue
                 });
             }

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -393,7 +393,8 @@ namespace AdoNetCore.AseClient.Internal
             }
             catch (Exception ex)
             {
-                readerSource.TrySetException(ex); // If we have already begun returning data, then this will get lost.
+                // If we have already begun returning data, then this will get lost.
+                if (!readerSource.TrySetException(ex)) throw;
             }
         }
 

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -609,11 +609,7 @@ namespace AdoNetCore.AseClient.Internal
             yield return command.CommandType == CommandType.StoredProcedure
                 ? BuildRpcToken(command, behavior)
                 : BuildLanguageToken(command, behavior);
-            //BuildParameterTokens
-            //foreach (var token in BuildParameterTokens(command.AseParameters, command.CommandType == CommandType.StoredProcedure))
-            //{
-            //    yield return token;
-            //}
+
             foreach (var token in BuildParameterTokens(command))
             {
                 yield return token;

--- a/src/AdoNetCore.AseClient/Internal/TokenReader.cs
+++ b/src/AdoNetCore.AseClient/Internal/TokenReader.cs
@@ -70,7 +70,7 @@ namespace AdoNetCore.AseClient.Internal
             {TokenType.TDS_PARAMFMT2, ParameterFormat2Token.Create },
             {TokenType.TDS_PARAMS, ParametersToken.Create },
             {TokenType.TDS_OPTIONCMD, OptionCommandToken.Create },
-            {TokenType.TDS_MSG, MessageToken.Create}
+            {TokenType.TDS_MSG, MessageToken.Create},
         };
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/TokenReader.cs
+++ b/src/AdoNetCore.AseClient/Internal/TokenReader.cs
@@ -70,7 +70,7 @@ namespace AdoNetCore.AseClient.Internal
             {TokenType.TDS_PARAMFMT2, ParameterFormat2Token.Create },
             {TokenType.TDS_PARAMS, ParametersToken.Create },
             {TokenType.TDS_OPTIONCMD, OptionCommandToken.Create },
-            {TokenType.TDS_MSG, MessageToken.Create},
+            {TokenType.TDS_MSG, MessageToken.Create}
         };
     }
 }

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -136,8 +136,7 @@ namespace AdoNetCore.AseClient.Internal
             switch (value)
             {
                 case string s:
-                    var count = Encoding.Unicode.GetByteCount(s);
-                    return count;
+                    return Encoding.Unicode.GetByteCount(s);
                 case char c:
                     return Encoding.Unicode.GetByteCount(new[] { c });
                 default:
@@ -230,21 +229,6 @@ namespace AdoNetCore.AseClient.Internal
                         }
                     }
                     return 35;
-                default:
-                    return 0;
-            }
-        }
-
-        
-
-        public static int GetTdsUserType(DbType dbType)
-        {
-            switch (dbType)
-            {
-                case DbType.String:
-                    return 35;
-                case DbType.StringFixedLength:
-                    return 34;
                 default:
                     return 0;
             }

--- a/src/AdoNetCore.AseClient/Internal/TypeMap.cs
+++ b/src/AdoNetCore.AseClient/Internal/TypeMap.cs
@@ -136,7 +136,8 @@ namespace AdoNetCore.AseClient.Internal
             switch (value)
             {
                 case string s:
-                    return Encoding.Unicode.GetByteCount(s);
+                    var count = Encoding.Unicode.GetByteCount(s);
+                    return count;
                 case char c:
                     return Encoding.Unicode.GetByteCount(new[] { c });
                 default:
@@ -206,6 +207,35 @@ namespace AdoNetCore.AseClient.Internal
 
             throw new NotSupportedException($"Unsupported data type {dbType} for parameter '{parameterName}'.");
         }
+
+        public static int GetUserType(DbType dbType, object value, int? length)
+        {
+            switch (dbType)
+            {
+                case DbType.StringFixedLength:
+                    return 34;
+                case DbType.String:
+                    if (DbToTdsMap.TryGetValue(dbType, out var result))
+                    {
+                        var tdsType = result(value, length ?? 0);
+                        switch (tdsType)
+                        {
+                            case TdsDataType.TDS_VARCHAR:
+                            case TdsDataType.TDS_LONGCHAR:
+                                return 34;
+                            case TdsDataType.TDS_LONGBINARY:
+                                return 35;
+                            case TdsDataType.TDS_BLOB:
+                                return 36;
+                        }
+                    }
+                    return 35;
+                default:
+                    return 0;
+            }
+        }
+
+        
 
         public static int GetTdsUserType(DbType dbType)
         {

--- a/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
@@ -332,7 +332,6 @@ namespace AdoNetCore.AseClient.Internal
                 default:
                     stream.WriteByte((byte)SerializationType.SER_DEFAULT);
                     stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
-                    //stream.WriteBlobSpecificIntPrefixedByteArray(Encoding.Unicode.GetBytes(value as string));
                     stream.WriteBlobSpecificTerminator();
                     break;
                     

--- a/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
@@ -330,7 +330,13 @@ namespace AdoNetCore.AseClient.Internal
                     stream.WriteBlobSpecificTerminator();
                     break;
                 default:
-                    throw new AseException($"TDS_BLOB support for {value.GetType().Name} not yet implemented");
+                    stream.WriteByte((byte)SerializationType.SER_DEFAULT);
+                    stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
+                    //stream.WriteBlobSpecificIntPrefixedByteArray(Encoding.Unicode.GetBytes(value as string));
+                    stream.WriteBlobSpecificTerminator();
+                    break;
+                    
+                    //throw new AseException($"TDS_BLOB support for {value.GetType().Name} not yet implemented");
             }
         }
 

--- a/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
+++ b/src/AdoNetCore.AseClient/Internal/ValueWriter.cs
@@ -334,8 +334,6 @@ namespace AdoNetCore.AseClient.Internal
                     stream.WriteNullableUShortPrefixedByteArray(format.ClassId);
                     stream.WriteBlobSpecificTerminator();
                     break;
-                    
-                    //throw new AseException($"TDS_BLOB support for {value.GetType().Name} not yet implemented");
             }
         }
 

--- a/test/AdoNetCore.AseClient.Tests/CodeSamples.cs
+++ b/test/AdoNetCore.AseClient.Tests/CodeSamples.cs
@@ -389,6 +389,27 @@ END";
             }
         }
 
+        [Test]
+        public void ExecuteScalar_Error_should_be_captured()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Default))
+            {
+                connection.Open();
+
+                var exception = Assert.Throws<AdoNetCore.AseClient.AseException>(() =>
+                {
+                    using (var command = connection.CreateCommand())
+                    {
+                        command.CommandText = "SELECT 1/0 As Error";
+
+                        var result = command.ExecuteScalar();
+                    }
+                });
+
+                Assert.That(exception.Message == "Divide by zero occurred.\n");
+            }
+        }
+
         private sealed class Customer
         {
             public string FirstName { get; set; }

--- a/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
+++ b/test/AdoNetCore.AseClient.Tests/ConnectionStrings.cs
@@ -17,6 +17,7 @@ namespace AdoNetCore.AseClient.Tests
         public static string Pooled100 => $"{Prefix}; Pooling=true; LoginTimeOut=1; Max Pool Size=100;";
         public static string PooledUtf8 => Pooled;
         public static string Cp850 => $"{PrefixNoCharSet}; charset=cp850;";
+        public static string Iso1 => $"{PrefixNoCharSet}; charset=iso_1;";
         public static string BigPacketSize => $"{Prefix}; Pooling=true; LoginTimeOut=1; PacketSize=2048;";
         public static string BigTextSize => $"{Prefix}; Pooling=true; LoginTimeOut=1; TextSize=131072;";
         public static string AseDecimalOn => $"{Prefix}; Pooling=true; LoginTimeOut=1; UseAseDecimal=1;";

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseExceptionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Dapper;
 using NUnit.Framework;
 
@@ -30,6 +31,17 @@ namespace AdoNetCore.AseClient.Tests.Integration
                 var ex = Assert.Throws<AseException>(() => connection.Execute($"dump database {dbName} to '/doesnotexist/foo' with compression = '101'"));
                 Assert.Greater(ex.Errors.Count, 1);
                 Assert.Greater(ex.Errors[0].Severity, 10);
+            }
+        }
+
+        [Test]
+        public void Execute_Sql_ThrowsAseException()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                var ex = Assert.Throws<AseException>(() => connection.QuerySingle<string>("select 1/0 as error"));
+                Assert.AreEqual(ex.Errors.Count, 1);
+                Assert.AreEqual(ex.Errors[0].Severity, 16);
             }
         }
     }

--- a/test/AdoNetCore.AseClient.Tests/Integration/Insert/TextTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/Insert/TextTests.cs
@@ -82,6 +82,9 @@ END";
         }
 
         [Test]
+        // Might have to increase the heap size with the command below
+        // exec sp_configure 'heap memory per user',228352
+        // http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc31644.1570/html/sag2/sag258.htm
         public void Insert_Parameter_Dapper(
             [ValueSource(nameof(Insert_Parameter_Types))] DbType dbType,
             [ValueSource(nameof(Insert_Parameter_Counts))] int count)
@@ -101,6 +104,9 @@ END";
         }
 
         [Test]
+        // Might have to increase the heap size with the command below
+        // exec sp_configure 'heap memory per user',228352
+        // http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc31644.1570/html/sag2/sag258.htm
         public void Insert_Parameter_With_Date_Dapper(
             [ValueSource(nameof(Insert_Parameter_Types))] DbType dbType,
             [ValueSource(nameof(Insert_Parameter_Counts))] int count)

--- a/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/LoginTests.cs
@@ -75,8 +75,9 @@ namespace AdoNetCore.AseClient.Tests.Integration
 
             try
             {
+                var source = Enumerable.Repeat(1, threads);
                 result = Parallel.ForEach(
-                    Enumerable.Repeat(1, threads),
+                    source,
                     new ParallelOptions
                     {
                         MaxDegreeOfParallelism = parallelism
@@ -100,7 +101,7 @@ namespace AdoNetCore.AseClient.Tests.Integration
 
         public static IEnumerable<TestCaseData> Login_Blitz_Cases()
         {
-            yield return new TestCaseData(10, 100, ConnectionStrings.Pooled10);
+            yield return new TestCaseData(10, 100, ConnectionStrings.Pooled100);
             yield return new TestCaseData(100, 1000, ConnectionStrings.Pooled100);
             yield return new TestCaseData(100, 10000, ConnectionStrings.Pooled100);
         }

--- a/test/AdoNetCore.AseClient.Tests/Integration/TextAllocatorProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TextAllocatorProcedureTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration
+{
+    [TestFixture]
+    [Category("extra")]
+    public class TextAllocatorProcedureTests
+    {
+        private readonly string _createTextLocatorProc = @"
+create procedure [dbo].[sp_test_true_echo_text_locator]
+  @input text_locator,
+  @output int output
+as
+begin
+  set @output = 100
+end";
+
+        private readonly string _dropTextLocatorProc = @"drop procedure [dbo].[sp_test_true_echo_text_locator]";
+
+        [SetUp]
+        public void Setup()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                //connection.Execute(_dropTextLocatorProc);
+
+                connection.Execute(_createTextLocatorProc);
+            }
+        }
+
+        [Test]
+        public void AssertTrue()
+        {
+            Assert.IsTrue(true);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Execute(_dropTextLocatorProc);
+            }
+        }
+
+    }
+}

--- a/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
@@ -477,7 +477,6 @@ end";
                         }
 
                         var count = connection.Execute("Select Fragment from test_text_table");
-                        //Assert.AreEqual(256, count);
                         transaction.Rollback();
                     }
                 }

--- a/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
@@ -236,7 +236,7 @@ end";
                     command.CommandType = CommandType.StoredProcedure;
 
                     //var expected = Enumerable.Repeat(new byte[] {0xde, 0xad, 0xbe, 0xef}, 64).SelectMany(x => x).Take(536386).ToArray();
-                    var text_locator = new string('x', 16384);
+                    var text_locator = new string('x', 106384);
                     var just_text = new string('y', 1024);
 
                     var p = command.CreateParameter();
@@ -259,8 +259,6 @@ end";
                     command.Parameters.Add(pOut);
 
                     command.ExecuteNonQuery();
-
-                    //Assert.AreEqual(expected, pOut.Value);
                 }
             }
         }
@@ -282,17 +280,11 @@ end";
                     var just_text = new string('y', length);
 
                     var p = command.CreateParameter();
-                    //p.ParameterName = "@text_locator_input";
-                    //p.Value = text_locator;
-                    //p.DbType = DbType.String;
-                    ////p.OverrideUserType = 0;//36; //19;
-                    //command.Parameters.Add(p);
 
                     p = command.CreateParameter();
                     p.ParameterName = "@input";
                     p.Value = just_text;
                     p.DbType = DbType.String;
-                    //p.OverrideUserType = 36;
                     command.Parameters.Add(p);
 
                     var pOut = command.CreateParameter();
@@ -303,8 +295,6 @@ end";
                     command.Parameters.Add(pOut);
 
                     command.ExecuteNonQuery();
-
-                    //Assert.AreEqual(expected, pOut.Value);
                 }
             }
         }
@@ -317,7 +307,7 @@ end";
         }
 
         [TestCaseSource(nameof(Insert_Text_Length))]
-        public void TextColumn_With_Data_Length_LessThan_16384_ReturnError(int length)
+        public void TextColumn_With_Data_Length_MoreThan_16384_ReturnSuccess(int length)
         {
             using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
@@ -334,7 +324,6 @@ end";
                         p.ParameterName = @"@fragment";
                         p.Value = fragment;
                         p.DbType = DbType.String;
-                        //p.OverrideUserType = 35;
                         p.Direction = ParameterDirection.Input;
 
                         fragmentCommand.Parameters.Add(p);
@@ -352,7 +341,6 @@ end";
         [TestCase(24000)]
         [TestCase(26000)]
         [TestCase(28000)]
-        //[TestCase(20000500)]
         [TestCase(20001000)]
         [TestCase(20001500)]
         [TestCase(20002000)]
@@ -381,7 +369,6 @@ end";
                         p.ParameterName = @"@fragment";
                         p.Value = fragment;
                         p.DbType = DbType.String;
-                        //p.OverrideUserType = 36;
                         p.Direction = ParameterDirection.Input;
 
                         fragmentCommand.Parameters.Add(p);

--- a/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
@@ -86,19 +86,11 @@ end";
             Logger.Enable();
         }
 
-        //[OneTimeSetUp]
-        [SetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             using (var connection = new AseConnection(ConnectionStrings.Pooled))
             {
-                //connection.Execute(_dropEchoTextProc);
-                //connection.Execute(_dropTextTable);
-                //connection.Execute(_dropEchoTextLocatorProc);
-                //connection.Execute(_dropTrueEchoTextLocatorProc);
-                //connection.Execute(_dropTextTypeColumnProc);
-                //connection.Execute(_dropJustTextProc);
-
                 connection.Execute(_createEchoTextProc);
                 connection.Execute(_createTextTable);
                 connection.Execute(_createEchoTextLocatorProc);
@@ -108,8 +100,7 @@ end";
             }
         }
 
-        //[OneTimeTearDown]
-        [TearDown]
+        [OneTimeTearDown]
         public void Teardown()
         {
             using (var connection = new AseConnection(ConnectionStrings.Pooled))
@@ -141,14 +132,12 @@ end";
                     p.ParameterName = "@input";
                     p.Value = expected;
                     p.DbType = DbType.String;
-                    p.OverrideUserType = 36;
                     command.Parameters.Add(p);
 
                     var pOut = command.CreateParameter();
                     pOut.ParameterName = "@output";
                     pOut.Value = DBNull.Value;
                     pOut.DbType = DbType.String;
-                    pOut.OverrideUserType = 36;
                     pOut.Direction = ParameterDirection.Output;
                     command.Parameters.Add(pOut);
 
@@ -170,16 +159,12 @@ end";
                     command.CommandText = "sp_test_echo_text_locator";
                     command.CommandType = CommandType.StoredProcedure;
 
-                    //var expected = Enumerable.Repeat(new byte[] {0xde, 0xad, 0xbe, 0xef}, 64).SelectMany(x => x).Take(536386).ToArray();
-                    //var expected = new string('x', 16384);
-                    //var expected = new string('x', 1063840);
                     var expected = $"Shawn test long comment {new string('A',1063840)}";
 
                     var p = command.CreateParameter();
                     p.ParameterName = "@input";
                     p.Value = expected;
                     p.DbType = DbType.String;
-                    p.OverrideUserType = 36;
                     command.Parameters.Add(p);
 
                     var pOut = command.CreateParameter();
@@ -191,7 +176,6 @@ end";
 
                     command.ExecuteNonQuery();
 
-                    //Assert.AreEqual(expected, pOut.Value);
                 }
             }
         }
@@ -215,14 +199,14 @@ end";
                     p.ParameterName = "@text_locator_input";
                     p.Value = text_locator;
                     p.DbType = DbType.String;
-                    p.OverrideUserType = 36; //19;
+                    //p.OverrideUserType = 36; //19;
                     command.Parameters.Add(p);
 
                     p = command.CreateParameter();
                     p.ParameterName = "@text_input";
                     p.Value = just_text;
                     p.DbType = DbType.String;
-                    p.OverrideUserType = 36;
+                    //p.OverrideUserType = 36;
                     command.Parameters.Add(p);
 
                     var pOut = command.CreateParameter();
@@ -259,14 +243,12 @@ end";
                     p.ParameterName = "@text_locator_input";
                     p.Value = text_locator;
                     p.DbType = DbType.String;
-                    //p.OverrideUserType = 0;//36; //19;
                     command.Parameters.Add(p);
 
                     p = command.CreateParameter();
                     p.ParameterName = "@text_input";
                     p.Value = just_text;
                     p.DbType = DbType.String;
-                    //p.OverrideUserType = 0;
                     command.Parameters.Add(p);
 
                     var pOut = command.CreateParameter();

--- a/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
@@ -1,0 +1,503 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using AdoNetCore.AseClient.Internal;
+using Dapper;
+using NUnit.Framework;
+
+namespace AdoNetCore.AseClient.Tests.Integration
+{
+    [TestFixture]
+    [Category("extra")]
+    public class TextEchoProcedureTests
+    {
+        //echo some bytes
+        private readonly string _createEchoTextProc = @"
+create procedure [dbo].[sp_test_echo_text]
+  @input text,
+  @output text output
+as
+begin
+  set @output = @input
+end";
+
+        private readonly string _dropEchoTextProc = @"drop procedure [dbo].[sp_test_echo_text]";
+
+        private readonly string _createTextTable = @"create table [dbo].[test_text_table] (Fragment text not null, CreatedDate datetime default getdate() not null)";
+
+        private readonly string _dropTextTable = @"drop table [dbo].[test_text_table]";
+
+        private readonly string _createEchoTextLocatorProc = @"
+create procedure [dbo].[sp_test_echo_text_locator]
+  @input text_locator,
+  @output int output
+as
+begin
+  set @output = 100
+end";
+        private readonly string _dropEchoTextLocatorProc = @"drop procedure [dbo].[sp_test_echo_text_locator]";
+
+        private readonly string _createTrueEchoTextLocatorProc = @"
+create procedure [dbo].[sp_test_true_echo_text_locator]
+  @input text_locator,
+  @output text output
+as
+DECLARE
+    @sCommentTL     text_locator
+
+begin
+  SELECT @sCommentTL = create_locator(text_locator, @input)
+  set @output = @input
+  --select @sCommentTL
+end";
+
+        private readonly string _dropTrueEchoTextLocatorProc = @"drop procedure [dbo].[sp_test_true_echo_text_locator]";
+
+        private readonly string _createTextTypeColumnProc = @"
+create procedure [dbo].[sp_test_text_type_coloumn]
+  @text_locator_input text_locator,
+  @text_input text,
+  @output int output
+as
+DECLARE
+    @sCommentTL     text_locator
+
+begin
+  --SELECT @sCommentTL = create_locator(text_locator, @text_input)
+  set @output = 10
+  --select @sCommentTL
+end";
+
+        private readonly string _dropTextTypeColumnProc = @"drop procedure [dbo].[sp_test_text_type_coloumn]";
+
+        private readonly string _createJustTextProc = @"
+create procedure [dbo].[sp_just_test_echo_text]
+  @input text,
+  @output int output
+as
+begin
+  set @output = 10
+end";
+        private readonly string _dropJustTextProc = @"drop procedure [dbo].[sp_just_test_echo_text]";
+        
+        public TextEchoProcedureTests()
+        {
+            Logger.Enable();
+        }
+
+        //[OneTimeSetUp]
+        [SetUp]
+        public void Setup()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                //connection.Execute(_dropEchoTextProc);
+                //connection.Execute(_dropTextTable);
+                //connection.Execute(_dropEchoTextLocatorProc);
+                //connection.Execute(_dropTrueEchoTextLocatorProc);
+                //connection.Execute(_dropTextTypeColumnProc);
+                //connection.Execute(_dropJustTextProc);
+
+                connection.Execute(_createEchoTextProc);
+                connection.Execute(_createTextTable);
+                connection.Execute(_createEchoTextLocatorProc);
+                connection.Execute(_createTrueEchoTextLocatorProc);
+                connection.Execute(_createTextTypeColumnProc);
+                connection.Execute(_createJustTextProc);
+            }
+        }
+
+        //[OneTimeTearDown]
+        [TearDown]
+        public void Teardown()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Execute(_dropEchoTextProc);
+                connection.Execute(_dropTextTable);
+                connection.Execute(_dropEchoTextLocatorProc);
+                connection.Execute(_dropTrueEchoTextLocatorProc);
+                connection.Execute(_dropTextTypeColumnProc);
+                connection.Execute(_dropJustTextProc);
+            }
+        }
+
+
+        [Test]
+        public void EchoText_Procedure_ShouldExecute()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "sp_test_echo_text";
+                    command.CommandType = CommandType.StoredProcedure;
+
+                    var expected = new string('x', 16384);
+
+                    var p = command.CreateParameter();
+                    p.ParameterName = "@input";
+                    p.Value = expected;
+                    p.DbType = DbType.String;
+                    p.OverrideUserType = 36;
+                    command.Parameters.Add(p);
+
+                    var pOut = command.CreateParameter();
+                    pOut.ParameterName = "@output";
+                    pOut.Value = DBNull.Value;
+                    pOut.DbType = DbType.String;
+                    pOut.OverrideUserType = 36;
+                    pOut.Direction = ParameterDirection.Output;
+                    command.Parameters.Add(pOut);
+
+                    command.ExecuteNonQuery();
+
+                    Assert.AreEqual(expected, pOut.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void TextLocator_Procedure_ShouldExecute()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "sp_test_echo_text_locator";
+                    command.CommandType = CommandType.StoredProcedure;
+
+                    //var expected = Enumerable.Repeat(new byte[] {0xde, 0xad, 0xbe, 0xef}, 64).SelectMany(x => x).Take(536386).ToArray();
+                    //var expected = new string('x', 16384);
+                    //var expected = new string('x', 1063840);
+                    var expected = $"Shawn test long comment {new string('A',1063840)}";
+
+                    var p = command.CreateParameter();
+                    p.ParameterName = "@input";
+                    p.Value = expected;
+                    p.DbType = DbType.String;
+                    p.OverrideUserType = 36;
+                    command.Parameters.Add(p);
+
+                    var pOut = command.CreateParameter();
+                    pOut.ParameterName = "@output";
+                    pOut.Value = DBNull.Value;
+                    pOut.DbType = DbType.Int32;
+                    pOut.Direction = ParameterDirection.Output;
+                    command.Parameters.Add(pOut);
+
+                    command.ExecuteNonQuery();
+
+                    //Assert.AreEqual(expected, pOut.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void TextTypeColumn_Procedure_ShouldExecute()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "sp_test_text_type_coloumn";
+                    command.CommandType = CommandType.StoredProcedure;
+
+                    //var expected = Enumerable.Repeat(new byte[] {0xde, 0xad, 0xbe, 0xef}, 64).SelectMany(x => x).Take(536386).ToArray();
+                    var text_locator = new string('x', 16384);
+                    var just_text = new string('y', 1024);
+
+                    var p = command.CreateParameter();
+                    p.ParameterName = "@text_locator_input";
+                    p.Value = text_locator;
+                    p.DbType = DbType.String;
+                    p.OverrideUserType = 36; //19;
+                    command.Parameters.Add(p);
+
+                    p = command.CreateParameter();
+                    p.ParameterName = "@text_input";
+                    p.Value = just_text;
+                    p.DbType = DbType.String;
+                    p.OverrideUserType = 36;
+                    command.Parameters.Add(p);
+
+                    var pOut = command.CreateParameter();
+                    pOut.ParameterName = "@output";
+                    pOut.Value = DBNull.Value;
+                    pOut.DbType = DbType.Int32;
+                    pOut.Direction = ParameterDirection.Output;
+                    command.Parameters.Add(pOut);
+
+                    command.ExecuteNonQuery();
+
+                    //Assert.AreEqual(expected, pOut.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void TextType_Proc_ShouldExecute_Ok()
+        {
+            //AdoNetCore.AseClient.AseException : The token datastream length was not correct. This is an internal protocol error.
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "sp_test_text_type_coloumn";
+                    command.CommandType = CommandType.StoredProcedure;
+
+                    //var expected = Enumerable.Repeat(new byte[] {0xde, 0xad, 0xbe, 0xef}, 64).SelectMany(x => x).Take(536386).ToArray();
+                    var text_locator = new string('x', 16384);
+                    var just_text = new string('y', 1024);
+
+                    var p = command.CreateParameter();
+                    p.ParameterName = "@text_locator_input";
+                    p.Value = text_locator;
+                    p.DbType = DbType.String;
+                    //p.OverrideUserType = 0;//36; //19;
+                    command.Parameters.Add(p);
+
+                    p = command.CreateParameter();
+                    p.ParameterName = "@text_input";
+                    p.Value = just_text;
+                    p.DbType = DbType.String;
+                    //p.OverrideUserType = 0;
+                    command.Parameters.Add(p);
+
+                    var pOut = command.CreateParameter();
+                    pOut.ParameterName = "@output";
+                    pOut.Value = DBNull.Value;
+                    pOut.DbType = DbType.Int32;
+                    pOut.Direction = ParameterDirection.Output;
+                    command.Parameters.Add(pOut);
+
+                    command.ExecuteNonQuery();
+
+                    //Assert.AreEqual(expected, pOut.Value);
+                }
+            }
+        }
+
+        [TestCaseSource(nameof(Insert_Text_Length))]
+        public void TextTypeColumn_Proc_ShouldExecute_Ok(int length)
+        {
+            //AdoNetCore.AseClient.AseException : The token datastream length was not correct. This is an internal protocol error.
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                connection.Open();
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = "sp_just_test_echo_text";
+                    command.CommandType = CommandType.StoredProcedure;
+
+                    //var expected = Enumerable.Repeat(new byte[] {0xde, 0xad, 0xbe, 0xef}, 64).SelectMany(x => x).Take(536386).ToArray();
+                    var text_locator = new string('x', 16383);
+                    var just_text = new string('y', length);
+
+                    var p = command.CreateParameter();
+                    //p.ParameterName = "@text_locator_input";
+                    //p.Value = text_locator;
+                    //p.DbType = DbType.String;
+                    ////p.OverrideUserType = 0;//36; //19;
+                    //command.Parameters.Add(p);
+
+                    p = command.CreateParameter();
+                    p.ParameterName = "@input";
+                    p.Value = just_text;
+                    p.DbType = DbType.String;
+                    //p.OverrideUserType = 36;
+                    command.Parameters.Add(p);
+
+                    var pOut = command.CreateParameter();
+                    pOut.ParameterName = "@output";
+                    pOut.Value = DBNull.Value;
+                    pOut.DbType = DbType.Int32;
+                    pOut.Direction = ParameterDirection.Output;
+                    command.Parameters.Add(pOut);
+
+                    command.ExecuteNonQuery();
+
+                    //Assert.AreEqual(expected, pOut.Value);
+                }
+            }
+        }
+
+
+        [Test]
+        public void AssertTrue()
+        {
+            Assert.IsTrue(true);
+        }
+
+        [TestCaseSource(nameof(Insert_Text_Length))]
+        public void TextColumn_With_Data_Length_LessThan_16384_ReturnError(int length)
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                using (var transaction = connection.BeginTransaction())
+                {
+                    using (var fragmentCommand = connection.CreateCommand())
+                    {
+                        fragmentCommand.CommandText = "insert into test_text_table (Fragment) VALUES (@fragment)";
+                        fragmentCommand.CommandType = CommandType.Text;
+                        fragmentCommand.Transaction = transaction;
+
+                        var fragment = new string('x', length);
+                        var p = fragmentCommand.CreateParameter();
+                        p.ParameterName = @"@fragment";
+                        p.Value = fragment;
+                        p.DbType = DbType.String;
+                        //p.OverrideUserType = 35;
+                        p.Direction = ParameterDirection.Input;
+
+                        fragmentCommand.Parameters.Add(p);
+
+                        var status = fragmentCommand.ExecuteNonQuery();
+                        transaction.Commit();
+                    }
+                }
+            }
+        }
+
+        //[TestCaseSource(nameof(Insert_Text_Length_GreaterThan_10000000))]
+        //sp_configure 'procedure cache size', 24000
+        [TestCase(2000)]
+        [TestCase(24000)]
+        [TestCase(26000)]
+        [TestCase(28000)]
+        //[TestCase(20000500)]
+        [TestCase(20001000)]
+        [TestCase(20001500)]
+        [TestCase(20002000)]
+        [TestCase(20002500)]
+        [TestCase(20003000)]
+        [TestCase(20003500)]
+        [TestCase(20004000)]
+        [TestCase(20004500)]
+        [TestCase(20005000)]
+        [TestCase(20005500)]
+        [TestCase(20006000)]
+        public void TextColumn_Length_gt_10000000_ReturnError(int length)
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                using (var transaction = connection.BeginTransaction())
+                {
+                    using (var fragmentCommand = connection.CreateCommand())
+                    {
+                        fragmentCommand.CommandText = "insert into test_text_table (Fragment) VALUES (@fragment)";
+                        fragmentCommand.CommandType = CommandType.Text;
+                        fragmentCommand.Transaction = transaction;
+
+                        var fragment = new string('x', length);
+                        var p = fragmentCommand.CreateParameter();
+                        p.ParameterName = @"@fragment";
+                        p.Value = fragment;
+                        p.DbType = DbType.String;
+                        //p.OverrideUserType = 36;
+                        p.Direction = ParameterDirection.Input;
+
+                        fragmentCommand.Parameters.Add(p);
+
+                        var status = fragmentCommand.ExecuteNonQuery();
+                        transaction.Commit();
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void Insert_Text_ShouldBeValid()
+        {
+            using (var connection = new AseConnection(ConnectionStrings.Pooled))
+            {
+                using (var transaction = connection.BeginTransaction())
+                {
+                    using (var fragmentCommand = connection.CreateCommand())
+                    {
+                        fragmentCommand.CommandText = "insert into test_text_table (Fragment) VALUES (@fragment)";
+                        fragmentCommand.CommandType = CommandType.Text;
+                        fragmentCommand.Transaction = transaction;
+
+                        var bytesSegmentSize = 16382;
+                        //var bytesSegmentSize = 2048;
+                        //var data = Enumerable.Repeat((byte) 0x65, 16384).ToArray();
+                        var data = Enumerable.Repeat((byte) 0x65, 6380).ToArray();
+                        var totalSegment = GetTotalSegments(data.Length, bytesSegmentSize );
+
+                        var pos = 0;
+                        for (var i = 1; i <= totalSegment; i++)
+                        {
+                            var len = data.Length - pos >= bytesSegmentSize
+                                ? bytesSegmentSize
+                                : (data.Length - pos);
+
+                            var fragment = new byte[len];
+                            Buffer.BlockCopy(data, pos, fragment, 0, len);
+
+                            fragmentCommand.Parameters.Clear();
+                            var p = fragmentCommand.CreateParameter();
+                            p.ParameterName = @"@fragment";
+                            p.Value = Convert.ToBase64String(fragment);
+                            p.DbType = DbType.String;
+                            p.Direction = ParameterDirection.Input;
+
+                            fragmentCommand.Parameters.Add(p);
+
+                            var status = fragmentCommand.ExecuteNonQuery();
+                            pos += len;
+                        }
+
+                        var count = connection.Execute("Select Fragment from test_text_table");
+                        //Assert.AreEqual(256, count);
+                        transaction.Rollback();
+                    }
+                }
+            }
+        }
+
+        private static int GetTotalSegments(int attachmentSize, int attachmentSegmentSize)
+        {
+            var total = attachmentSize / attachmentSegmentSize;
+            return (total > 0 && attachmentSize % attachmentSegmentSize == 0) ? total : total + 1;
+        }
+
+        public static IEnumerable<int> Insert_Text_Length()
+        {
+            yield return 4096;
+            yield return 4097;
+            yield return 8192;
+            yield return 8193;
+            yield return 10000;
+            yield return 16384;
+            yield return 16385;
+            yield return 100000;
+            yield return 1000000;
+            yield return 10000000;
+            //yield return 100000000;
+            //yield return 1000000000;
+        }
+
+        public static IEnumerable<int> Insert_Text_Length_GreaterThan_10000000()
+        {
+            yield return 20000500;
+            yield return 20001000;
+            yield return 20001500;
+            yield return 20002000;
+            yield return 20002500;
+            yield return 20003000;
+            yield return 20003500;
+            yield return 20004000;
+            yield return 20004500;
+            yield return 20005000;
+            yield return 20005500;
+            yield return 20006000;
+        }
+
+    }
+}


### PR DESCRIPTION
Fix issue [182 ](https://github.com/DataAction/AdoNetCore.AseClient/issues/182) where exception not throw in ExecuteScalar() when it should
Addressed issue [183 ](https://github.com/DataAction/AdoNetCore.AseClient/issues/183) where SchemaTableBuilder failed because of duplicate column names return from the "sp_oledb_getindexinfo" by not setting the **IsUnique** and **IsKey** metadata value and instead use the default value