### PR TITLE
Addressing Issues #196, #192 and #205

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net46;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>0.19.1</VersionPrefix>
+    <VersionPrefix>0.19.2</VersionPrefix>
     <AssemblyVersion>0.11.0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <Authors>dataaction</Authors>
@@ -9,7 +9,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/DataAction/AdoNetCore.AseClient</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageReleaseNotes>Refer to GitHub - https://github.com/DataAction/AdoNetCore.AseClient/releases/tag/0.19.1</PackageReleaseNotes>
+    <PackageReleaseNotes>Refer to GitHub - https://github.com/DataAction/AdoNetCore.AseClient/releases/tag/0.19.2</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/DataAction/AdoNetCore.AseClient</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/AdoNetCore.AseClient/AseCommandBuilder.cs
+++ b/src/AdoNetCore.AseClient/AseCommandBuilder.cs
@@ -224,12 +224,15 @@ namespace AdoNetCore.AseClient
                     if (dataTable != null)
                     {
                         // If there is no primary key on the table, then throw MissingPrimaryKeyException.
-                        var isKeyColumn = dataTable.Columns["IsKey"];
+                        var isKeyColumn = dataTable.Columns[SchemaTableColumn.IsKey];
+                        var isUniqueColumn = dataTable.Columns[SchemaTableColumn.IsUnique];
+
                         var hasKey = false;
 
                         foreach (DataRow columnDescriptorRow in dataTable.Rows)
                         {
-                            hasKey |= (bool)columnDescriptorRow[isKeyColumn];
+                            hasKey |= (bool)columnDescriptorRow[isKeyColumn] ||
+                                      (bool)columnDescriptorRow[isUniqueColumn];
 
                             if (hasKey)
                             {

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Data;
 using System.Data.Common;
 using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Internal;
 
@@ -676,14 +675,4 @@ namespace AdoNetCore.AseClient
     /// the TraceEnter and TraceExit events.</para>
     /// </remarks>
     public delegate void TraceExitEventHandler(AseConnection connection, object source, string method, object returnValue);
-
-    /// <summary>
-    /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
-    /// </summary>
-    /// <param name="sender">An object that contains state information for this validation.</param>
-    /// <param name="certificate">The certificate used to authenticate the remote party.</param>
-    /// <param name="chain">The chain of certificate authorities associated with the remote certificate.</param>
-    /// <param name="sslPolicyErrors">One or more errors associated with the remote certificate.</param>
-    /// <returns>A System.Boolean value that determines whether the specified certificate is accepted for authentication.</returns>
-    public delegate bool RemoteCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors);
 }

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -627,6 +627,9 @@ namespace AdoNetCore.AseClient
             }
         }
 
+        /// <summary>
+        /// Allow consumer to override the default certificate validation
+        /// </summary>
         public RemoteCertificateValidationCallback UserCertificateValidationCallback { get; set; }
 
     }
@@ -674,25 +677,13 @@ namespace AdoNetCore.AseClient
     /// </remarks>
     public delegate void TraceExitEventHandler(AseConnection connection, object source, string method, object returnValue);
 
-    //
-    // Summary:
-    //     Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
-    //
-    // Parameters:
-    //   sender:
-    //     An object that contains state information for this validation.
-    //
-    //   certificate:
-    //     The certificate used to authenticate the remote party.
-    //
-    //   chain:
-    //     The chain of certificate authorities associated with the remote certificate.
-    //
-    //   sslPolicyErrors:
-    //     One or more errors associated with the remote certificate.
-    //
-    // Returns:
-    //     A System.Boolean value that determines whether the specified certificate is accepted
-    //     for authentication.
+    /// <summary>
+    /// Verifies the remote Secure Sockets Layer (SSL) certificate used for authentication.
+    /// </summary>
+    /// <param name="sender">An object that contains state information for this validation.</param>
+    /// <param name="certificate">The certificate used to authenticate the remote party.</param>
+    /// <param name="chain">The chain of certificate authorities associated with the remote certificate.</param>
+    /// <param name="sslPolicyErrors">One or more errors associated with the remote certificate.</param>
+    /// <returns>A System.Boolean value that determines whether the specified certificate is accepted for authentication.</returns>
     public delegate bool RemoteCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors);
 }

--- a/src/AdoNetCore.AseClient/AseParameterCollection.cs
+++ b/src/AdoNetCore.AseClient/AseParameterCollection.cs
@@ -263,10 +263,10 @@ namespace AdoNetCore.AseClient
         /// <returns>A new <see cref="AseParameter" /> object.</returns>
         public AseParameter Add(AseParameter parameter)
         {
-            if (parameter != null)
-            {
-                _parameters.Add(parameter);
-            }
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+            if (Contains(parameter)) throw new ArgumentException($"parameter name '{parameter.ParameterName}' is already in the collection");
+
+            _parameters.Add(parameter);
             return parameter;
         }
 
@@ -379,6 +379,7 @@ namespace AdoNetCore.AseClient
         {
             if (value is AseParameter p)
             {
+                if (Contains(p)) throw new ArgumentException($"Parameter name: '{p.ParameterName}' is already registered", nameof(value));
                 return ((IList)_parameters).Add(p);
             }
             return -1;
@@ -438,11 +439,19 @@ namespace AdoNetCore.AseClient
         /// Returns -1 when the object does not exist in the <see cref="AseParameterCollection" />.</returns>
         public int IndexOf(AseParameter value)
         {
-            if (value != null)
+            if (value == null) return -1;
+            for (var i = 0; i < _parameters.Count; i++)
             {
-                for (var i = 0; i < _parameters.Count; i++)
+                if (string.IsNullOrWhiteSpace(value.ParameterName))
                 {
                     if (value == _parameters[i])
+                    {
+                        return i;
+                    }
+                }
+                else
+                {
+                    if (value == _parameters[i] || value.ParameterName == _parameters[i].ParameterName)
                     {
                         return i;
                     }
@@ -459,6 +468,7 @@ namespace AdoNetCore.AseClient
         /// <param name="parameter">The <see cref="AseParameter" /> object to add to the collection.</param>
         public override void Insert(int index, object parameter)
         {
+            if (Contains(parameter)) throw new ArgumentException($"parameter name '{parameter}' is already in the collection");
             ((IList)_parameters).Insert(index, parameter);
         }
 
@@ -469,6 +479,7 @@ namespace AdoNetCore.AseClient
         /// <param name="parameter">The <see cref="AseParameter" /> object to add to the collection.</param>
         public void Insert(int index, AseParameter parameter)
         {
+            if (Contains(parameter)) throw new ArgumentException($"parameter name '{parameter.ParameterName}' is already in the collection");
             ((IList)_parameters).Insert(index, parameter);
         }
 
@@ -521,10 +532,7 @@ namespace AdoNetCore.AseClient
         /// <param name="index">The starting index of the array.</param>
         public override void CopyTo(Array array, int index)
         {
-            if (array != null)
-            {
-                ((IList)_parameters).CopyTo(array, index);
-            }
+            ((IList)_parameters).CopyTo(array, index);
         }
 
         /// <summary>

--- a/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
@@ -1,3 +1,5 @@
+using System.Net.Security;
+
 namespace AdoNetCore.AseClient.Interface
 {
     internal interface IConnectionPoolManager

--- a/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Interface/IConnectionPoolManager.cs
@@ -2,7 +2,7 @@ namespace AdoNetCore.AseClient.Interface
 {
     internal interface IConnectionPoolManager
     {
-        IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier);
+        IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier, RemoteCertificateValidationCallback userCertificateValidationCallback = null);
         void Release(string connectionString, IInternalConnection connection);
         void ClearPool(string connectionString);
         void ClearPools();

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net.Security;
 using AdoNetCore.AseClient.Interface;
 
 namespace AdoNetCore.AseClient.Internal

--- a/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
+++ b/src/AdoNetCore.AseClient/Internal/ConnectionPoolManager.cs
@@ -14,14 +14,14 @@ namespace AdoNetCore.AseClient.Internal
 
         private static readonly ConcurrentDictionary<string, IConnectionPool> Pools = new ConcurrentDictionary<string, IConnectionPool>(StringComparer.OrdinalIgnoreCase);
 
-        public IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier)
+        public IInternalConnection Reserve(string connectionString, IConnectionParameters parameters, IInfoMessageEventNotifier eventNotifier, RemoteCertificateValidationCallback userCertificateValidationCallback = null)
         {
             return Pools.GetOrAdd(connectionString, _ =>
             {
 #if ENABLE_ARRAY_POOL
-                var internalConnectionFactory = new InternalConnectionFactory(parameters, BufferPool);
+                var internalConnectionFactory = new InternalConnectionFactory(parameters, BufferPool, userCertificateValidationCallback);
 #else
-                var internalConnectionFactory = new InternalConnectionFactory(parameters);
+                var internalConnectionFactory = new InternalConnectionFactory(parameters, userCertificateValidationCallback);
 #endif
 
                 return new ConnectionPool(parameters, internalConnectionFactory);

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -66,10 +66,10 @@ namespace AdoNetCore.AseClient.Internal
 
         public static FormatItem CreateForParameter(AseParameter parameter, DbEnvironment env, AseCommand command)
         {
+            parameter.AseDbType = TypeMap.InferType(parameter);
+
             var dbType = parameter.DbType;
             var length = TypeMap.GetFormatLength(dbType, parameter, env.Encoding);
-
-            parameter.AseDbType = TypeMap.InferType(parameter);
 
             var format = command.FormatItem;
             var parameterName = parameter.ParameterName ?? command.Parameters.IndexOf(parameter).ToString();

--- a/src/AdoNetCore.AseClient/Internal/FormatItem.cs
+++ b/src/AdoNetCore.AseClient/Internal/FormatItem.cs
@@ -64,49 +64,59 @@ namespace AdoNetCore.AseClient.Internal
         /// </summary>
         public SerializationType SerializationType { get; set; }
 
-        public static FormatItem CreateForParameter(AseParameter parameter, DbEnvironment env, CommandType commandType)
+        public static FormatItem CreateForParameter(AseParameter parameter, DbEnvironment env, AseCommand command)
         {
-            parameter.AseDbType = TypeMap.InferType(parameter);
-
             var dbType = parameter.DbType;
-
             var length = TypeMap.GetFormatLength(dbType, parameter, env.Encoding);
 
-            var format = new FormatItem
-            {
-                AseDbType = parameter.AseDbType,
-                ParameterName = parameter.ParameterName,
-                IsOutput = parameter.IsOutput,
-                IsNullable = parameter.IsNullable,
-                Length = length,
-                DataType = TypeMap.GetTdsDataType(dbType, parameter.SendableValue, length, parameter.ParameterName),
-                UserType = TypeMap.GetUserType(dbType, parameter.SendableValue, length)
-            };
+            parameter.AseDbType = TypeMap.InferType(parameter);
 
-            //fixup the FormatItem's BlobType for strings and byte arrays
-            if (format.DataType == TdsDataType.TDS_BLOB)
+            var format = command.FormatItem;
+            var parameterName = parameter.ParameterName ?? command.Parameters.IndexOf(parameter).ToString();
+            if (!(command.FormatItem != null && command.FormatItem.ParameterName == parameterName &&
+                  command.FormatItem.AseDbType == parameter.AseDbType))
             {
-                switch (parameter.DbType)
+                format = new FormatItem
                 {
-                    case DbType.AnsiString:
-                        format.BlobType = BlobType.BLOB_LONGCHAR;
-                        break;
-                    case DbType.String:
-                        format.BlobType = BlobType.BLOB_UNICHAR;
-                        // This is far less than ideal but at the time of addressing this issue whereby if the
-                        // BlobType is a BLOB_UNICHAR then the UserType would need to be 36 when it
-                        // is a stored proc otherwise it would need to be zero (0).
-                        //
-                        // In the future, we'd need to overhaul how TDS_BLOB is structured especially
-                        // around BLOB_UNICHAR and the UserType that it should return in a more consistent way
-                        if (commandType != CommandType.StoredProcedure)
-                            format.UserType = 0;
+                    AseDbType = parameter.AseDbType,
+                    ParameterName = parameter.ParameterName,
+                    IsOutput = parameter.IsOutput,
+                    IsNullable = parameter.IsNullable,
+                    Length = length,
+                    DataType = TypeMap.GetTdsDataType(dbType, parameter.SendableValue, length, parameter.ParameterName),
+                    UserType = TypeMap.GetUserType(dbType, parameter.SendableValue, length)
+                };
 
-                        break;
-                    case DbType.Binary:
-                        format.BlobType = BlobType.BLOB_LONGBINARY;
-                        break;
+                //fixup the FormatItem's BlobType for strings and byte arrays
+                if (format.DataType == TdsDataType.TDS_BLOB)
+                {
+                    switch (parameter.DbType)
+                    {
+                        case DbType.AnsiString:
+                            format.BlobType = BlobType.BLOB_LONGCHAR;
+                            break;
+                        case DbType.String:
+                            format.BlobType = BlobType.BLOB_UNICHAR;
+                            // This is far less than ideal but at the time of addressing this issue whereby if the
+                            // BlobType is a BLOB_UNICHAR then the UserType would need to be 36 when it
+                            // is a stored proc otherwise it would need to be zero (0).
+                            //
+                            // In the future, we'd need to overhaul how TDS_BLOB is structured especially
+                            // around BLOB_UNICHAR and the UserType that it should return in a more consistent way
+                            if (command.CommandType != CommandType.StoredProcedure)
+                                format.UserType = 0;
+
+                            break;
+                        case DbType.Binary:
+                            format.BlobType = BlobType.BLOB_LONGBINARY;
+                            break;
+                    }
                 }
+            }
+            else
+            {
+                format.DataType = TypeMap.GetTdsDataType(dbType, parameter.SendableValue, length, parameter.ParameterName);
+                format.UserType = TypeMap.GetUserType(dbType, parameter.SendableValue, length);
             }
 
             //fixup the FormatItem's length,scale,precision for decimals

--- a/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnection.cs
@@ -669,11 +669,7 @@ SET FMTONLY OFF";
 
             foreach (var parameter in command.Parameters.SendableParameters)
             {
-                var parameterName = parameter.ParameterName ?? command.Parameters.IndexOf(parameter).ToString();
-                if (!(command.FormatItem != null && command.FormatItem.ParameterName == parameterName && command.FormatItem.AseDbType == parameter.AseDbType))
-                {
-                    command.FormatItem = FormatItem.CreateForParameter(parameter, _environment, command.CommandType);
-                }
+                command.FormatItem = FormatItem.CreateForParameter(parameter, _environment, command);
 
                 formatItems.Add(command.FormatItem);
                 parameterItems.Add(new ParametersToken.Parameter

--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -19,7 +19,8 @@ namespace AdoNetCore.AseClient.Internal
     internal class InternalConnectionFactory : IInternalConnectionFactory
     {
         private readonly IConnectionParameters _parameters;
-        private readonly RemoteCertificateValidationCallback _userCertificateValidationCallback;
+        private readonly System.Net.Security.RemoteCertificateValidationCallback _userCertificateValidationCallback;
+
 
 #if ENABLE_ARRAY_POOL
         private readonly System.Buffers.ArrayPool<byte> _arrayPool;
@@ -33,10 +34,7 @@ namespace AdoNetCore.AseClient.Internal
 #endif
         {
             _parameters = parameters;
-            if (userCertificateValidationCallback == null)
-                userCertificateValidationCallback = GetDefaultUserCertificateValidationCallback();
-
-            _userCertificateValidationCallback = userCertificateValidationCallback;
+            _userCertificateValidationCallback = userCertificateValidationCallback == null ? UserCertificateValidationCallback : new System.Net.Security.RemoteCertificateValidationCallback(userCertificateValidationCallback);
 
 #if ENABLE_ARRAY_POOL
             _arrayPool = arrayPool;
@@ -116,7 +114,7 @@ namespace AdoNetCore.AseClient.Internal
 
                 if (_parameters.Encryption)
                 {
-                    sslStream = new SslStream(networkStream, false, _userCertificateValidationCallback.Invoke);
+                    sslStream = new SslStream(networkStream, false, _userCertificateValidationCallback);
 
                     var authenticate = sslStream.AuthenticateAsClientAsync(_parameters.Server);
 
@@ -187,32 +185,30 @@ namespace AdoNetCore.AseClient.Internal
         }
 
 
-        private RemoteCertificateValidationCallback GetDefaultUserCertificateValidationCallback()
+        private bool UserCertificateValidationCallback(object sender, X509Certificate serverCertificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
-            //object sender, X509Certificate serverCertificate, X509Chain chain, SslPolicyErrors sslPolicyErrors
-            return (sender, serverCertificate, chain, sslPolicyErrors) => {
-                var certificateChainPolicyErrors = (sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) == SslPolicyErrors.RemoteCertificateChainErrors;
-                var otherPolicyErrors = (sslPolicyErrors & ~SslPolicyErrors.RemoteCertificateChainErrors) != SslPolicyErrors.None;
+            var certificateChainPolicyErrors = (sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) == SslPolicyErrors.RemoteCertificateChainErrors;
+            var otherPolicyErrors = (sslPolicyErrors & ~SslPolicyErrors.RemoteCertificateChainErrors) != SslPolicyErrors.None;
 
-                // We're not concerned with chain errors as we verify the chain below.
-                if (otherPolicyErrors)
-                {
-                    Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(GetDefaultUserCertificateValidationCallback)} secure connection failed due to policy errors: {sslPolicyErrors}");
-                    return false;
-                }
+            // We're not concerned with chain errors as we verify the chain below.
+            if (otherPolicyErrors)
+            {
+                Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(UserCertificateValidationCallback)} secure connection failed due to policy errors: {sslPolicyErrors}");
+                return false;
+            }
 
-                var mergedStatusFlags = X509ChainStatusFlags.NoError;
-                foreach (var status in chain.ChainStatus)
-                {
-                    mergedStatusFlags |= status.Status;
-                }
+            var mergedStatusFlags = X509ChainStatusFlags.NoError;
+            foreach (var status in chain.ChainStatus)
+            {
+                mergedStatusFlags |= status.Status;
+            }
 
-                var trustedCerts = LoadTrustedFile(_parameters.TrustedFile);
-                if (trustedCerts == null)
-                {
-                    Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(GetDefaultUserCertificateValidationCallback)} secure connection failed due to missing TrustedFile parameter.");
-                    return false;
-                }
+            var trustedCerts = LoadTrustedFile(_parameters.TrustedFile);
+            if (trustedCerts == null)
+            {
+                Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(UserCertificateValidationCallback)} secure connection failed due to missing TrustedFile parameter.");
+                return false;
+            }
 
 #if !(NETCOREAPP1_0 || NETCOREAPP1_1) // these frameworks do not have the following X509Certificate2 constructor...
             // sometimes the chain policy is only a partial chain because it doesn't include a self signed root?
@@ -233,41 +229,40 @@ namespace AdoNetCore.AseClient.Internal
             }
 #endif
 
-                var untrustedRootChainStatusFlags = (mergedStatusFlags & X509ChainStatusFlags.UntrustedRoot) == X509ChainStatusFlags.UntrustedRoot;
-                var otherChainStatusFlags = (mergedStatusFlags & ~X509ChainStatusFlags.UntrustedRoot) != X509ChainStatusFlags.NoError;
+            var untrustedRootChainStatusFlags = (mergedStatusFlags & X509ChainStatusFlags.UntrustedRoot) == X509ChainStatusFlags.UntrustedRoot;
+            var otherChainStatusFlags = (mergedStatusFlags & ~X509ChainStatusFlags.UntrustedRoot) != X509ChainStatusFlags.NoError;
 
-                if (otherChainStatusFlags)
-                {
-                    Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(GetDefaultUserCertificateValidationCallback)} secure connection failed due to chain status: {mergedStatusFlags}");
-                    return false;
-                }
+            if (otherChainStatusFlags)
+            {
+                Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(UserCertificateValidationCallback)} secure connection failed due to chain status: {mergedStatusFlags}");
+                return false;
+            }
 
-                if (!(certificateChainPolicyErrors || untrustedRootChainStatusFlags))
+            if (!(certificateChainPolicyErrors || untrustedRootChainStatusFlags))
+            {
+                //No chain Errors, we will trust the server certificate.
+                return true;
+            }
+
+            // If any certificates in the chain are trusted, then we will trust the server certificate.
+            // To do this fairly quickly we can check if thumbprints exist in the set of trusted roots.
+            var set = new HashSet<string>(trustedCerts.Select(c => c.Thumbprint));
+
+            // the chain is in an array from leaf at 0 to root at [count - 1]
+            // looping from end to start should find cases generated according to sybase documentation on the first attempt
+            // but it is possible that someone puts an intermediate or even the leaf cert in their trusted file
+            for (int i = chain.ChainElements.Count - 1; i >= 0; i--)
+            {
+                var potentialTrusted = chain.ChainElements[i].Certificate.Thumbprint;
+                if (set.Contains(potentialTrusted))
                 {
-                    //No chain Errors, we will trust the server certificate.
                     return true;
                 }
+            }
 
-                // If any certificates in the chain are trusted, then we will trust the server certificate.
-                // To do this fairly quickly we can check if thumbprints exist in the set of trusted roots.
-                var set = new HashSet<string>(trustedCerts.Select(c => c.Thumbprint));
+            Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(UserCertificateValidationCallback)} secure connection failed due to missing root or intermediate certificate in the certificate store, or the TrustedFile.");
 
-                // the chain is in an array from leaf at 0 to root at [count - 1]
-                // looping from end to start should find cases generated according to sybase documentation on the first attempt
-                // but it is possible that someone puts an intermediate or even the leaf cert in their trusted file
-                for (int i = chain.ChainElements.Count - 1; i >= 0; i--)
-                {
-                    var potentialTrusted = chain.ChainElements[i].Certificate.Thumbprint;
-                    if (set.Contains(potentialTrusted))
-                    {
-                        return true;
-                    }
-                }
-
-                Logger.Instance?.WriteLine($"{nameof(InternalConnectionFactory)}.{nameof(GetDefaultUserCertificateValidationCallback)} secure connection failed due to missing root or intermediate certificate in the certificate store, or the TrustedFile.");
-
-                return false;
-            };
+            return false;
         }
 
         private static X509Certificate2[] LoadTrustedFile(string trustedFile)

--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -19,7 +19,7 @@ namespace AdoNetCore.AseClient.Internal
     internal class InternalConnectionFactory : IInternalConnectionFactory
     {
         private readonly IConnectionParameters _parameters;
-        private readonly System.Net.Security.RemoteCertificateValidationCallback _userCertificateValidationCallback;
+        private readonly RemoteCertificateValidationCallback _userCertificateValidationCallback;
 
 
 #if ENABLE_ARRAY_POOL
@@ -34,7 +34,7 @@ namespace AdoNetCore.AseClient.Internal
 #endif
         {
             _parameters = parameters;
-            _userCertificateValidationCallback = userCertificateValidationCallback == null ? UserCertificateValidationCallback : new System.Net.Security.RemoteCertificateValidationCallback(userCertificateValidationCallback);
+            _userCertificateValidationCallback = userCertificateValidationCallback ?? UserCertificateValidationCallback;
 
 #if ENABLE_ARRAY_POOL
             _arrayPool = arrayPool;

--- a/src/AdoNetCore.AseClient/Internal/SchemaTableBuilder.cs
+++ b/src/AdoNetCore.AseClient/Internal/SchemaTableBuilder.cs
@@ -130,17 +130,12 @@ namespace AdoNetCore.AseClient.Internal
         private void TryLoadKeyInfo(DataTable table, string baseTableNameValue, string baseSchemaNameValue, string baseCatalogNameValue)
         {
             if (_connection == null)
-            {
                 throw new InvalidOperationException("Invalid AseCommand.Connection");
-            }
 
             if (_connection.State != ConnectionState.Open)
-            {
                 throw new InvalidOperationException("Invalid AseCommand.Connection.ConnectionState");
-            }
 
-            if (!string.IsNullOrWhiteSpace(baseTableNameValue) &&
-                !string.IsNullOrWhiteSpace(baseCatalogNameValue))
+            if (string.IsNullOrWhiteSpace(baseTableNameValue))
                 return;
 
             using (var command = _connection.CreateCommand())

--- a/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
+++ b/test/AdoNetCore.AseClient.Tests/AdoNetCore.AseClient.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
@@ -34,9 +35,11 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="Sybase.AdoNet4.AseClient">

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseCommandTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseCommandTests.cs
@@ -178,6 +178,89 @@ namespace AdoNetCore.AseClient.Tests.Integration
             }
         }
 
+        [TestCaseSource(nameof(ReUseCommandTypeData))]
+        public void Command_Reuse_ShouldWork_For_Null_Value(System.Data.DbType dbType, Type type, object value)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+                using (var cmd = connection.CreateCommand())
+                {
+                    var sql = @"SELECT @value";
+                    var p = cmd.CreateParameter();
+                    p.ParameterName = "@value";
+                    p.DbType = dbType;
+                    p.Value = Convert.ChangeType(value, type);
+                    cmd.CommandText = sql;
+                    cmd.Parameters.Add(p);
+                    cmd.ExecuteScalar();
+
+                    p = cmd.CreateParameter();
+                    p.ParameterName = "@value";
+                    p.DbType = dbType;
+                    p.Value = null;
+                    cmd.Parameters.Clear();
+                    cmd.Parameters.Add(p);
+
+                    cmd.ExecuteScalar();
+                }
+            }
+        }
+
+        
+        [TestCaseSource(nameof(ReUseCommandTypeData))]
+        public void Command_Reuse_ShouldWork_For_NonNull_Value(System.Data.DbType dbType, Type type, object value)
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+                using (var cmd = connection.CreateCommand())
+                {
+                    var sql = @"SELECT @value";
+                    var p = cmd.CreateParameter();
+                    p.ParameterName = "@value";
+                    p.DbType = dbType;
+                    p.Value = null;
+                    cmd.CommandText = sql;
+                    cmd.Parameters.Add(p);
+                    cmd.ExecuteScalar();
+
+                    p = cmd.CreateParameter();
+                    p.ParameterName = "@value";
+                    p.DbType = dbType;
+                    p.Value = Convert.ChangeType(value, type);
+                    cmd.Parameters.Clear();
+                    cmd.Parameters.Add(p);
+
+                    cmd.ExecuteScalar();
+                }
+            }
+        }
+        private static IEnumerable<TestCaseData> ReUseCommandTypeData()
+        {
+            yield return new TestCaseData(System.Data.DbType.Boolean, typeof(bool), false);
+            yield return new TestCaseData(System.Data.DbType.Byte, typeof(byte), 12);
+            yield return new TestCaseData(System.Data.DbType.SByte, typeof(sbyte), 2);
+            yield return new TestCaseData(System.Data.DbType.Int16, typeof(short), 3);
+            yield return new TestCaseData(System.Data.DbType.UInt16, typeof(ushort), 4);
+            yield return new TestCaseData(System.Data.DbType.Int32, typeof(int), 23);
+            yield return new TestCaseData(System.Data.DbType.UInt32, typeof(uint), 45);
+            yield return new TestCaseData(System.Data.DbType.Int64, typeof(long), 76434755);
+            yield return new TestCaseData(System.Data.DbType.UInt64, typeof(ulong), 1223);
+            yield return new TestCaseData(System.Data.DbType.String, typeof(string), "If it could only be like this always—always summer, always alone, the fruit always ripe");
+            yield return new TestCaseData(System.Data.DbType.AnsiString, typeof(string), "Doubt thou the stars are fire; Doubt that the sun doth move; Doubt truth to be a liar; But never doubt I love");
+            yield return new TestCaseData(System.Data.DbType.AnsiStringFixedLength, typeof(string), "For never was a story of more woe than this of Juliet and her Romeo.");
+            yield return new TestCaseData(System.Data.DbType.Guid, typeof(string), "e2207b47-3fce-4187-808f-e206398a9133");
+            yield return new TestCaseData(System.Data.DbType.Decimal, typeof(decimal), 342.23);
+            yield return new TestCaseData(System.Data.DbType.Currency, typeof(decimal), 1233.3);
+            yield return new TestCaseData(System.Data.DbType.Single, typeof(float), 20.34f);
+            yield return new TestCaseData(System.Data.DbType.Double, typeof(double), 3423.234d);
+            yield return new TestCaseData(System.Data.DbType.DateTime, typeof(DateTime), "2019-03-13 03:20:35.23 AM");
+            yield return new TestCaseData(System.Data.DbType.Date, typeof(DateTime), "2018-07-04 23:20:35.23 PM");
+            yield return new TestCaseData(System.Data.DbType.Time, typeof(DateTime), "2014-09-10 23:20:35");
+
+        }
+
         private static IEnumerable<TestCaseData> GetDataTypeName_ShouldWork_Cases()
         {
             yield return new TestCaseData("convert(unichar(2), 'À')", "unichar");
@@ -244,5 +327,15 @@ namespace AdoNetCore.AseClient.Tests.Integration
             yield return new TestCaseData("convert(nvarchar(2), 'a')", "nvarchar");
             yield return new TestCaseData("convert(nvarchar(2), null)", "nvarchar");
         }
+
+        public T CastObject<T>(object input) {   
+            return (T) input;   
+        }
+
+        public T ConvertObject<T>(object input) {
+            return (T) Convert.ChangeType(input, typeof(T));
+        }
+
     }
+
 }

--- a/test/AdoNetCore.AseClient.Tests/Integration/AseCommandTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/AseCommandTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Xml;
 using AdoNetCore.AseClient.Internal;
 using AdoNetCore.AseClient.Tests.Util;
@@ -236,28 +237,45 @@ namespace AdoNetCore.AseClient.Tests.Integration
                 }
             }
         }
+
+        [Test]
+        public void Command_Duplicate_Parameter_Name_Should_Throws_ArgumentException()
+        {
+            using (var connection = GetConnection())
+            {
+                connection.Open();
+                var sql = "select @p1, @p2";
+                var aseCommand = connection.CreateCommand();
+                aseCommand.CommandText = sql;
+                aseCommand.CommandType = CommandType.Text;
+                aseCommand.Parameters.Add("@p1", "test");
+                aseCommand.Parameters.Add("@p2", "test2");
+                Assert.Throws<ArgumentException>(() => aseCommand.Parameters.Add("@p1", "test3"));
+            }
+        }
+
         private static IEnumerable<TestCaseData> ReUseCommandTypeData()
         {
-            yield return new TestCaseData(System.Data.DbType.Boolean, typeof(bool), false);
-            yield return new TestCaseData(System.Data.DbType.Byte, typeof(byte), 12);
-            yield return new TestCaseData(System.Data.DbType.SByte, typeof(sbyte), 2);
-            yield return new TestCaseData(System.Data.DbType.Int16, typeof(short), 3);
-            yield return new TestCaseData(System.Data.DbType.UInt16, typeof(ushort), 4);
-            yield return new TestCaseData(System.Data.DbType.Int32, typeof(int), 23);
-            yield return new TestCaseData(System.Data.DbType.UInt32, typeof(uint), 45);
-            yield return new TestCaseData(System.Data.DbType.Int64, typeof(long), 76434755);
-            yield return new TestCaseData(System.Data.DbType.UInt64, typeof(ulong), 1223);
-            yield return new TestCaseData(System.Data.DbType.String, typeof(string), "If it could only be like this always—always summer, always alone, the fruit always ripe");
-            yield return new TestCaseData(System.Data.DbType.AnsiString, typeof(string), "Doubt thou the stars are fire; Doubt that the sun doth move; Doubt truth to be a liar; But never doubt I love");
-            yield return new TestCaseData(System.Data.DbType.AnsiStringFixedLength, typeof(string), "For never was a story of more woe than this of Juliet and her Romeo.");
-            yield return new TestCaseData(System.Data.DbType.Guid, typeof(string), "e2207b47-3fce-4187-808f-e206398a9133");
-            yield return new TestCaseData(System.Data.DbType.Decimal, typeof(decimal), 342.23);
-            yield return new TestCaseData(System.Data.DbType.Currency, typeof(decimal), 1233.3);
-            yield return new TestCaseData(System.Data.DbType.Single, typeof(float), 20.34f);
-            yield return new TestCaseData(System.Data.DbType.Double, typeof(double), 3423.234d);
-            yield return new TestCaseData(System.Data.DbType.DateTime, typeof(DateTime), "2019-03-13 03:20:35.23 AM");
-            yield return new TestCaseData(System.Data.DbType.Date, typeof(DateTime), "2018-07-04 23:20:35.23 PM");
-            yield return new TestCaseData(System.Data.DbType.Time, typeof(DateTime), "2014-09-10 23:20:35");
+            yield return new TestCaseData(DbType.Boolean, typeof(bool), false);
+            yield return new TestCaseData(DbType.Byte, typeof(byte), 12);
+            yield return new TestCaseData(DbType.SByte, typeof(sbyte), 2);
+            yield return new TestCaseData(DbType.Int16, typeof(short), 3);
+            yield return new TestCaseData(DbType.UInt16, typeof(ushort), 4);
+            yield return new TestCaseData(DbType.Int32, typeof(int), 23);
+            yield return new TestCaseData(DbType.UInt32, typeof(uint), 45);
+            yield return new TestCaseData(DbType.Int64, typeof(long), 76434755);
+            yield return new TestCaseData(DbType.UInt64, typeof(ulong), 1223);
+            yield return new TestCaseData(DbType.String, typeof(string), "If it could only be like this always—always summer, always alone, the fruit always ripe");
+            yield return new TestCaseData(DbType.AnsiString, typeof(string), "Doubt thou the stars are fire; Doubt that the sun doth move; Doubt truth to be a liar; But never doubt I love");
+            yield return new TestCaseData(DbType.AnsiStringFixedLength, typeof(string), "For never was a story of more woe than this of Juliet and her Romeo.");
+            yield return new TestCaseData(DbType.Guid, typeof(string), "e2207b47-3fce-4187-808f-e206398a9133");
+            yield return new TestCaseData(DbType.Decimal, typeof(decimal), 342.23);
+            yield return new TestCaseData(DbType.Currency, typeof(decimal), 1233.3);
+            yield return new TestCaseData(DbType.Single, typeof(float), 20.34f);
+            yield return new TestCaseData(DbType.Double, typeof(double), 3423.234d);
+            yield return new TestCaseData(DbType.DateTime, typeof(DateTime), "2019-03-13 03:20:35.23 AM");
+            yield return new TestCaseData(DbType.Date, typeof(DateTime), "2018-07-04 23:20:35.23 PM");
+            yield return new TestCaseData(DbType.Time, typeof(DateTime), "2014-09-10 23:20:35");
 
         }
 

--- a/test/AdoNetCore.AseClient.Tests/Integration/ConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/ConnectionTests.cs
@@ -43,5 +43,21 @@ namespace AdoNetCore.AseClient.Tests.Integration
                 Assert.AreEqual(30294, ex.Errors[0].MessageNumber);
             }
         }
+
+        [Test]
+        //Note: for this to work, we would need a sybase SSL setup with a separate SSL port
+        //for this test, no certificate on the consuming side
+        public void UserCertificateValidationCallback_ShouldWork()
+        {
+            var isDelegateCalled = false;
+
+            using (var connection = new AseConnection(ConnectionStrings.Tls))
+            {
+                connection.UserCertificateValidationCallback = (o, cert, chain, pol) => { isDelegateCalled = true; return true; };
+
+                connection.Open();
+                Assert.True(isDelegateCalled);
+            }
+        }
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Integration/TextEchoProcedureTests.cs
@@ -447,8 +447,8 @@ end";
                         fragmentCommand.CommandType = CommandType.Text;
                         fragmentCommand.Transaction = transaction;
 
-                        //var bytesSegmentSize = 16382;
-                        var bytesSegmentSize = 2048;
+                        var bytesSegmentSize = 16382;
+                        //var bytesSegmentSize = 2048;
                         var data = Enumerable.Repeat((byte) 0x65, 16384).ToArray();
                         //var data = Enumerable.Repeat((byte) 0x65, 6380).ToArray();
                         var totalSegment = GetTotalSegments(data.Length, bytesSegmentSize );

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -166,13 +166,14 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IInfoMessageEventNotifier>()))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IInfoMessageEventNotifier>(),It.IsAny<RemoteCertificateValidationCallback>()))
                 .Returns(mockConnection.Object);
 
             mockConnection.Setup(x => x.ChangeDatabase(It.IsAny<string>()));
 
             var connection = new AseConnection("Data Source=myASEserver;Port=5000;Database=foo;Uid=myUsername;Pwd=myPassword;", mockConnectionPoolManager.Object);
 
+            //connection.UserCertificateValidationCallback = (sender, certificate, chain, errors) => true;
             // Act
             connection.Open();
             connection.ChangeDatabase("bar");
@@ -188,7 +189,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IInfoMessageEventNotifier>()))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IInfoMessageEventNotifier>(),It.IsAny<RemoteCertificateValidationCallback>()))
                 .Returns(mockConnection.Object);
 
             mockConnection.Setup(x => x.ChangeDatabase(It.IsAny<string>()));
@@ -272,7 +273,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
 
             mockConnectionPoolManager
-                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IInfoMessageEventNotifier>()))
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IInfoMessageEventNotifier>(),It.IsAny<RemoteCertificateValidationCallback>()))
                 .Returns(mockConnection.Object);
 
             return mockConnectionPoolManager.Object;

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -173,14 +173,13 @@ namespace AdoNetCore.AseClient.Tests.Unit
 
             var connection = new AseConnection("Data Source=myASEserver;Port=5000;Database=foo;Uid=myUsername;Pwd=myPassword;", mockConnectionPoolManager.Object);
 
-            //connection.UserCertificateValidationCallback = (sender, certificate, chain, errors) => true;
             // Act
             connection.Open();
             connection.ChangeDatabase("bar");
-
             // Assert
             // No error...
         }
+
         [Test]
         public void ChangeDatabase_WhenNotOpen_Succeeds()
         {

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Net.Security;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Internal;
 using Moq;


### PR DESCRIPTION
Fixing issue #196 
* Caching command parameter metadata is only applicable for TdsDataType.TDS_BLOB and not the other as we still need to determine DataType and UserType both of which depends parameter.SendableValue where that can be null
* Adding more test cases raised by issue #196
* Address issue #192 for duplicate parameter name
* Update test cases for #192
* Fix bug in SchemaTableBuilder to not skip valid table
* Partially address issue #188 by include the IsUnique as well as IsKey in the validation to determine hasKey
