### PR TITLE
Fix #179 catch-all masking and add more test cases

### DIFF
--- a/src/AdoNetCore.AseClient/Token/CatchAllToken.cs
+++ b/src/AdoNetCore.AseClient/Token/CatchAllToken.cs
@@ -1,7 +1,8 @@
-using System.IO;
 using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Interface;
 using AdoNetCore.AseClient.Internal;
+using System;
+using System.IO;
 
 namespace AdoNetCore.AseClient.Token
 {
@@ -30,95 +31,96 @@ namespace AdoNetCore.AseClient.Token
             }
         }
 
+        private uint CalculateRemainingLength(Stream stream)
+        {
+            var len = ClassifyLength(_type);
+            if (len == CatchAllLength.Undefined || len == CatchAllLength.Absent)
+            {
+                // We cannot successfully read undefined / absent length without corrupting the stream
+                // Undefined has no real logical mapping
+                // Absent are context-sensitive and based on prior tokens in the stream (e.g. TDS_ALTROW is of varied length based on TDS_ALTFMT)
+                throw new InvalidOperationException($"Attempted to use catch-all token with token {_type} of {len} length");
+            }
+            return ReadLength(stream, len);
+        }
+
         /// <summary>
         /// The token's length or the length of its remaining length indicator is encoded in the token's type.
         /// </summary>
-        /// <param name="stream"></param>
+        /// <param name="type"></param>
         /// <returns></returns>
-        private uint CalculateRemainingLength(Stream stream)
+        internal static CatchAllLength ClassifyLength(byte type)
         {
+            if (type == (byte) TokenType.TDS_CURDECLARE3)
+            {
+                // Default handling in the spec appears to be incorrect
+                // Return the length as defined by the token itself
+                return CatchAllLength.Dynamic_4;
+            }
+
             // 5.2.2 Fixed Length - xx11xxxx
-            // xx1111xx - 8 bytes
-            if ((_type & 0b0011_1100) == 0b0011_1100)
+            switch (type & 0b0011_1100)
             {
-                return 8;
+                case 0b0011_1100: return CatchAllLength.Fixed_8; // xx1111xx - 8 bytes
+                case 0b0011_1000: return CatchAllLength.Fixed_4; // xx1110xx - 4 bytes
+                case 0b0011_0100: return CatchAllLength.Fixed_2; // xx1101xx - 2 bytes
+                case 0b0011_0000: return CatchAllLength.Fixed_1; // xx1100xx - 1 byte
             }
 
-            // xx1110xx - 4 bytes
-            if ((_type & 0b0011_1000) == 0b0011_1000)
+            // 5.2.3 Variable Length - any other pattern                
+            switch (type & 0b1111_0000)
             {
-                return 4;
+                case 0b1010_0000: return CatchAllLength.Dynamic_2; // 1010xxxx - ushort
+                case 0b1110_0000: return CatchAllLength.Dynamic_2; // 1110xxxx - ushort
+                case 0b1000_0000: return CatchAllLength.Dynamic_2; // 1000xxxx - ushort
             }
 
-            // xx1101xx - 2 bytes
-            if ((_type & 0b0011_0100) == 0b0011_0100)
+            switch (type & 0b1111_1100)
             {
-                return 2;
-            }
-
-            // xx1100xx - 1 byte
-            if ((_type & 0b0011_0000) == 0b0011_0000)
-            {
-                return 1;
-            }
-
-            // 5.2.3 Variable Length - any other pattern
-            // 1010xxxx - ushort
-            if ((_type & 0b1010_0000) == 0b1010_0000)
-            {
-                return stream.ReadUShort();
-            }
-
-            // 1110xxxx - ushort
-            if ((_type & 0b1110_0000) == 0b1110_0000)
-            {
-                return stream.ReadUShort();
-            }
-
-            // 1000xxxx - ushort
-            if ((_type & 0b1000_0000) == 0b1000_0000)
-            {
-                return stream.ReadUShort();
-            }
-
-            // 001000xx - uint
-            if ((_type & 0b0010_0000) == 0b0010_0000)
-            {
-                return stream.ReadUInt();
-            }
-
-            // 011000xx - uint
-            if ((_type & 0b0110_0000) == 0b0110_0000)
-            {
-                return stream.ReadUInt();
-            }
-
-            // 001001xx - byte
-            if ((_type & 0b0010_0100) == 0b0010_0100)
-            {
-                return (uint) stream.ReadByte();
-            }
-
-            // 001010xx - byte
-            if ((_type & 0b0010_1000) == 0b0010_1000)
-            {
-                return (uint) stream.ReadByte();
-            }
-
-            // 011001xx - byte
-            if ((_type & 0b0110_0100) == 0b0110_0100)
-            {
-                return (uint) stream.ReadByte();
-            }
-
-            // 011010xx - byte
-            if ((_type & 0b0110_1000) == 0b0110_1000)
-            {
-                return (uint) stream.ReadByte();
+                case 0b0010_0000: return CatchAllLength.Dynamic_4; // 001000xx - uint
+                case 0b0110_0000: return CatchAllLength.Dynamic_4; // 011000xx - uint
+                case 0b0010_0100: return CatchAllLength.Dynamic_1; // 001001xx - byte
+                case 0b0010_1000: return CatchAllLength.Dynamic_1; // 001010xx - byte
+                case 0b0110_0100: return CatchAllLength.Dynamic_1; // 011001xx - byte
+                case 0b0110_1000: return CatchAllLength.Dynamic_1; // 011010xx - byte
             }
 
             // 5.2.1 Zero Length - 110xxxxx
-            return 0;
+            if ((type & 0b1110_0000) == 0b1100_0000)
+            {
+                return CatchAllLength.Absent;
+            }
+            return CatchAllLength.Undefined;
+        }
+
+        internal static uint ReadLength(Stream stream, CatchAllLength length)
+        {
+            switch (length)
+            {
+                case CatchAllLength.Undefined: return 0;
+                case CatchAllLength.Absent: return 0;
+                case CatchAllLength.Fixed_1: return 1;
+                case CatchAllLength.Fixed_2: return 2;
+                case CatchAllLength.Fixed_4: return 4;
+                case CatchAllLength.Fixed_8: return 8;
+                case CatchAllLength.Dynamic_1: return (uint)stream.ReadByte();
+                case CatchAllLength.Dynamic_2: return stream.ReadUShort();
+                case CatchAllLength.Dynamic_4: return stream.ReadUInt();
+            }
+            throw new NotImplementedException("Unrecognised CatchAllLength " + length);
+        }
+
+        internal enum CatchAllLength
+        {
+            Undefined,
+            Absent,
+            Fixed_1,
+            Fixed_2,
+            Fixed_4,
+            Fixed_8,
+            Dynamic_1,
+            Dynamic_2,
+            Dynamic_4
         }
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Unit/CatchAllTokenTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/CatchAllTokenTests.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
+using AdoNetCore.AseClient.Enum;
 using AdoNetCore.AseClient.Internal;
 using AdoNetCore.AseClient.Token;
 using NUnit.Framework;
+using static AdoNetCore.AseClient.Token.CatchAllToken;
 
 namespace AdoNetCore.AseClient.Tests.Unit
 {
@@ -16,9 +20,10 @@ namespace AdoNetCore.AseClient.Tests.Unit
             var t = new CatchAllToken(type);
             using (var ms = new MemoryStream())
             {
-                t.Read(ms, new DbEnvironment(), null);
-
-                Assert.AreEqual(0, ms.Position);
+                // All zero-length tokens are not actually zero-length.
+                // They have a length, but it is derived from prior tokens (eg TDS_ALTROW's length is determined by a prior TDS_ALTFMT token)
+                // As such, we cannot process the tokens with Catch-All without corrupting the stream's next-token position
+                Assert.Throws<InvalidOperationException>(() => t.Read(ms, new DbEnvironment(), null));
             }
         }
 
@@ -110,6 +115,397 @@ namespace AdoNetCore.AseClient.Tests.Unit
                 t.Read(ms, new DbEnvironment(), null);
 
                 Assert.AreEqual(ms.Length, ms.Position);
+            }
+        }
+
+        [TestCase(CatchAllLength.Undefined, 0u, 0u)]
+        [TestCase(CatchAllLength.Absent, 0u, 0u)]
+        [TestCase(CatchAllLength.Fixed_1, 0u, 1u)]
+        [TestCase(CatchAllLength.Fixed_2, 0u, 2u)]
+        [TestCase(CatchAllLength.Fixed_4, 0u, 4u)]
+        [TestCase(CatchAllLength.Fixed_8, 0u, 8u)]
+        [TestCase(CatchAllLength.Dynamic_1, 1u, 0b1101_0110u)]
+        [TestCase(CatchAllLength.Dynamic_2, 2u, 0b0111_0101__1101_0110u)]
+        [TestCase(CatchAllLength.Dynamic_4, 4u, 0b1111_0000__1011_0010__0111_0101__1101_0110u)]
+        public void CatchAllLength_ReadLength(object cal, uint expectedRead, uint expectedLength)
+        {
+            using (var ms = new MemoryStream())
+            {
+                ms.Write(new byte[] { 0b1101_0110, 0b0111_0101, 0b1011_0010, 0b1111_0000, 0b1100_1100 });
+                ms.Seek(0, SeekOrigin.Begin);
+                var actualLen = ReadLength(ms, (CatchAllLength)cal);
+                Assert.AreEqual(expectedRead, ms.Position);
+                Assert.AreEqual(expectedLength, actualLen);
+            }
+        }
+
+        [TestCaseSource(nameof(ExhaustiveLengthTestInput))]
+        public void ExhaustiveLengthTest(object tokenType, object expectedLength)
+        {
+            var cl = ClassifyLength((byte) tokenType);
+            Assert.AreEqual((CatchAllLength) expectedLength, cl);
+        }
+
+        [TestCaseSource(nameof(DefinedTokenLengthTestInput))]
+        public void DefinedTokenLengthTest(object tokenType, object expectedLength)
+        {
+            var cl = ClassifyLength((byte)tokenType);
+            Assert.AreEqual((CatchAllLength)expectedLength, cl);
+        }
+
+        public static IEnumerable<object[]> ExhaustiveLengthTestInput
+        {
+            get
+            {
+                // Values expected by strictly obeying the type/length definitions
+                var items = new List<object[]>
+                {
+                    new object[] { (TokenType) 0b0000_0000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_0001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_0010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_0011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_0100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_0101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_0110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_0111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0000_1111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_0111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0001_1111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0010_0000, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0010_0001, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0010_0010, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0010_0011, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0010_0100, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_0101, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_0110, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_0111, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_1000, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_1001, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_1010, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_1011, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0010_1100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0010_1101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0010_1110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0010_1111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0011_0000, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0011_0001, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0011_0010, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0011_0011, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0011_0100, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0011_0101, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0011_0110, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0011_0111, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0011_1000, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0011_1001, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0011_1010, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0011_1011, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0011_1100, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b0011_1101, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b0011_1110, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b0011_1111, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b0100_0000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_0001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_0010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_0011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_0100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_0101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_0110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_0111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0100_1111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_0111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0101_1111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0110_0000, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0110_0001, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0110_0010, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0110_0011, CatchAllLength.Dynamic_4 },
+                    new object[] { (TokenType) 0b0110_0100, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_0101, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_0110, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_0111, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_1000, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_1001, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_1010, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_1011, CatchAllLength.Dynamic_1 },
+                    new object[] { (TokenType) 0b0110_1100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0110_1101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0110_1110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0110_1111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b0111_0000, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0111_0001, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0111_0010, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0111_0011, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b0111_0100, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0111_0101, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0111_0110, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0111_0111, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b0111_1000, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0111_1001, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0111_1010, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0111_1011, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b0111_1100, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b0111_1101, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b0111_1110, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b0111_1111, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1000_0000, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_0001, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_0010, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_0011, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_0100, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_0101, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_0110, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_0111, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1000, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1001, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1010, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1011, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1100, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1101, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1110, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1000_1111, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1001_0000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_0001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_0010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_0011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_0100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_0101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_0110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_0111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1000, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1001, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1010, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1011, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1100, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1101, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1110, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1001_1111, CatchAllLength.Undefined },
+                    new object[] { (TokenType) 0b1010_0000, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_0001, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_0010, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_0011, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_0100, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_0101, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_0110, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_0111, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1000, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1001, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1010, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1011, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1100, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1101, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1110, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1010_1111, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1011_0000, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1011_0001, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1011_0010, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1011_0011, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1011_0100, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1011_0101, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1011_0110, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1011_0111, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1011_1000, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1011_1001, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1011_1010, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1011_1011, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1011_1100, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1011_1101, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1011_1110, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1011_1111, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1100_0000, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_0001, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_0010, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_0011, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_0100, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_0101, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_0110, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_0111, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_1000, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_1001, CatchAllLength.Absent },
+                    // TDS spec 5.2.3 claims KEY token is a zero length token in pattern 1010xxxx;
+                    // But KEY is actually 0xCA (0b1100_1010)
+                    new object[] { (TokenType) 0b1100_1010, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_1011, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_1100, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_1101, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_1110, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1100_1111, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_0000, CatchAllLength.Absent },
+                    // TDS spec 5.2.3 claims ROW token is a zero length token in pattern 1110xxxx;
+                    // But ROW is actually 0xD1 (0b1101_0001)
+                    new object[] { (TokenType) 0b1101_0001, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_0010, CatchAllLength.Absent },
+                    // TDS spec 5.2.3 claims ALTROW token is a zero length token in pattern 1110xxxx;
+                    // But ALTROW is actually 0xD3 (0b1101_0011)
+                    new object[] { (TokenType) 0b1101_0011, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_0100, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_0101, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_0110, CatchAllLength.Absent },
+                    // TDS spec 5.2.3 claims PARAMS token is a zero length token in pattern 1110xxxx;
+                    // But PARAMS is actually 0xD7 (0b1101_0111)
+                    new object[] { (TokenType) 0b1101_0111, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1000, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1001, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1010, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1011, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1100, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1101, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1110, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1101_1111, CatchAllLength.Absent },
+                    new object[] { (TokenType) 0b1110_0000, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_0001, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_0010, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_0011, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_0100, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_0101, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_0110, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_0111, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1000, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1001, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1010, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1011, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1100, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1101, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1110, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1110_1111, CatchAllLength.Dynamic_2 },
+                    new object[] { (TokenType) 0b1111_0000, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1111_0001, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1111_0010, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1111_0011, CatchAllLength.Fixed_1 },
+                    new object[] { (TokenType) 0b1111_0100, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1111_0101, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1111_0110, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1111_0111, CatchAllLength.Fixed_2 },
+                    new object[] { (TokenType) 0b1111_1000, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1111_1001, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1111_1010, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1111_1011, CatchAllLength.Fixed_4 },
+                    new object[] { (TokenType) 0b1111_1100, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1111_1101, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1111_1110, CatchAllLength.Fixed_8 },
+                    new object[] { (TokenType) 0b1111_1111, CatchAllLength.Fixed_8 },
+                };
+
+                for (int i = 0; i < items.Count; i++)
+                {
+                    if (i != (byte) items[i][0])
+                    {
+                        throw new InvalidOperationException("Broken assumption - test data not valid");
+                    }
+                }
+
+                // Broken value - definition of TDS_CURDECLARE3 conflicts with the packet type length rules.
+                // Assume TDS_CURDECLARE3 is correct instead
+
+                items[(byte)TokenType.TDS_CURDECLARE3][1] = CatchAllLength.Dynamic_4;
+
+                return items;
+            }
+        }
+
+        public static IEnumerable<object[]> DefinedTokenLengthTestInput
+        {
+            get
+            {
+                // Values expected as defined by each token's definition
+                var items = new List<object[]>
+                {
+                    new object[] { TokenType.TDS_ALTFMT, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_ALTNAME, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_ALTROW, CatchAllLength.Absent },
+                    new object[] { TokenType.TDS_CAPABILITY, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_COLINFO, CatchAllLength.Dynamic_2 },
+                    // new object[] { TokenType.TDS_COLFMT, ? },
+                    // new object[] { TokenType.TDS_COLFMTOLD, ? },
+                    new object[] { TokenType.TDS_CONTROL, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURCLOSE, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURDECLARE, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURDECLARE2, CatchAllLength.Dynamic_4 },
+                    new object[] { TokenType.TDS_CURDECLARE3, CatchAllLength.Dynamic_4 },
+                    new object[] { TokenType.TDS_CURDELETE, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURFETCH, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURINFO, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURINFO2, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURINFO3, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CUROPEN, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_CURUPDATE, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_DBRPC, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_DBRPC2, CatchAllLength.Dynamic_2 },
+                    // new object[] { TokenType.TDS_DEBUGCMD, ? },
+                    new object[] { TokenType.TDS_DONE, CatchAllLength.Fixed_8 },
+                    new object[] { TokenType.TDS_DONEINPROC, CatchAllLength.Fixed_8 },
+                    new object[] { TokenType.TDS_DONEPROC, CatchAllLength.Fixed_8 },
+                    new object[] { TokenType.TDS_DYNAMIC, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_DYNAMIC2, CatchAllLength.Dynamic_4 },
+                    new object[] { TokenType.TDS_EED, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_ENVCHANGE, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_ERROR, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_EVENTNOTICE, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_INFO, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_KEY, CatchAllLength.Absent },
+                    new object[] { TokenType.TDS_LANGUAGE, CatchAllLength.Dynamic_4 },
+                    new object[] { TokenType.TDS_LOGINACK, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_LOGOUT, CatchAllLength.Fixed_1 },
+                    new object[] { TokenType.TDS_MSG, CatchAllLength.Dynamic_1 },
+                    new object[] { TokenType.TDS_OFFSET, CatchAllLength.Fixed_4 },
+                    new object[] { TokenType.TDS_OPTIONCMD, CatchAllLength.Dynamic_2 },
+                    // new object[] { TokenType.TDS_OPTIONCMD2, ? },
+                    new object[] { TokenType.TDS_ORDERBY, CatchAllLength.Dynamic_2 }, // "#Columns" = Length as it is 1:1 with the number of bytes in the packet
+                    new object[] { TokenType.TDS_ORDERBY2, CatchAllLength.Dynamic_4 },
+                    new object[] { TokenType.TDS_PARAMFMT, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_PARAMFMT2, CatchAllLength.Dynamic_4 },
+                    new object[] { TokenType.TDS_PARAMS, CatchAllLength.Absent },
+                    // new object[] { TokenType.TDS_PROCID, ? },
+                    new object[] { TokenType.TDS_RPC, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_RETURNSTATUS, CatchAllLength.Fixed_4 },
+                    new object[] { TokenType.TDS_RETURNVALUE, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_ROW, CatchAllLength.Absent },
+                    new object[] { TokenType.TDS_ROWFMT, CatchAllLength.Dynamic_2 },
+                    new object[] { TokenType.TDS_ROWFMT2, CatchAllLength.Dynamic_4 },
+                    new object[] { TokenType.TDS_TABNAME, CatchAllLength.Dynamic_2 },
+                };
+
+                return items;
             }
         }
     }


### PR DESCRIPTION
Fixes the incorrect masking in CatchAllToken.
TDS_CURDECLARE3 also does not obey the rules on token length, so it has been special-cased.
Additionally, all "Zero-Length" tokens are not actually zero-length; their length is defined by prior tokens in the stream, so it would cause unpredictable errors if they are encountered by the CatchAllToken; as such they now throw exceptions instead.