### PR TITLE
Preventing caching IP endpoint in connection

### DIFF
--- a/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
+++ b/src/AdoNetCore.AseClient/Internal/InternalConnectionFactory.cs
@@ -73,10 +73,7 @@ namespace AdoNetCore.AseClient.Internal
         {
             try
             {
-                if (_endpoint == null)
-                {
-                    _endpoint = CreateEndpoint(_parameters.Server, _parameters.Port, token);
-                }
+                _endpoint = CreateEndpoint(_parameters.Server, _parameters.Port, token);
 
                 return new Socket(_endpoint.AddressFamily, SocketType.Stream, ProtocolType.IP);
             }


### PR DESCRIPTION
when database failover to DR, the ip address will change and cached ip endpoint still point to original ip which will cause issue